### PR TITLE
Add git to the required packages for the tests

### DIFF
--- a/tests/vars/CentOS-7.yml
+++ b/tests/vars/CentOS-7.yml
@@ -4,5 +4,6 @@
 
 nbde_client_test_packages:
   - cryptsetup
+  - git
 
 # vim:set ts=2 sw=2 et:

--- a/tests/vars/CentOS-8.yml
+++ b/tests/vars/CentOS-8.yml
@@ -4,5 +4,6 @@
 
 nbde_client_test_packages:
   - cryptsetup
+  - git
 
 # vim:set ts=2 sw=2 et:

--- a/tests/vars/Fedora.yml
+++ b/tests/vars/Fedora.yml
@@ -4,5 +4,6 @@
 
 nbde_client_test_packages:
   - cryptsetup
+  - git
 
 # vim:set ts=2 sw=2 et:

--- a/tests/vars/RedHat-7.yml
+++ b/tests/vars/RedHat-7.yml
@@ -4,5 +4,6 @@
 
 nbde_client_test_packages:
   - cryptsetup
+  - git
 
 # vim:set ts=2 sw=2 et:

--- a/tests/vars/RedHat-8.yml
+++ b/tests/vars/RedHat-8.yml
@@ -4,5 +4,6 @@
 
 nbde_client_test_packages:
   - cryptsetup
+  - git
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Since we are using the git module to download nbde_server during the
tests, we also need to make sure we have git available.