### PR TITLE
use consistent tls/crypto parameter naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,24 @@ These are the variables that can be passed to the role:
 | **Name** | **Default/Choices** | **Description** |
 |----------|-------------|------|
 | `device` | | specifies the path of the backing device of an encrypted device on the managed host. This device must be already configured as a LUKS device before using the role (**REQUIRED**). |
-| `passphrase` | | a valid passphrase for opening/unlocking the specified device. Recommend vault encrypting the passphrase. See https://docs.ansible.com/ansible/latest/user_guide/vault.html |
-| `key_file` | | either the absolute or relative path, on the control node, of a key file valid for opening/unlocking the specified device. |
+| `encryption_password` | | a valid password or passphrase for opening/unlocking the specified device. Recommend vault encrypting the value. See https://docs.ansible.com/ansible/latest/user_guide/vault.html |
+| `encryption_key_src` | | either the absolute or relative path, on the control node, of a file containing an encryption key valid for opening/unlocking the specified device.  The role will copy this file to the managed node(s). |
 | `state` | **present** / absent | specifies whether a binding with the configuration described should be added or removed. Setting state to present (the default) means a binding will be added; setting state to absent means a binding will be removed from the device/slot. |
 | `slot` | `1` | specifies the slot to use for the binding. |
 | `servers` | |  specifies a list of servers to bind to. To enable high availability, specify more than one server here. |
 | `threshold` | `1` | specifies the threshold for the Shamir Secret Sharing (SSS) scheme that is put in place when using more than one server. When using multiple servers, threshold indicates how many of those servers should succeed, in terms of decryption, in order to complete the process of recovering the LUKS passphrase to open the device. |
-| `passphrase_temporary` | `no` | If yes, the passphrase that was provided via the `passphrase` or `key_file` arguments will be used to unlock the device and then it will be removed from the LUKS device after the binding operation completes, i.e. it will not be valid anymore. To be used if device has been previously created with a dummy passphrase (for example by an automated install like kickstart that set up some sort of "default" password), which the role should replace by a stronger one. |
+| `password_temporary` | `no` | If yes, the password or passphrase that was provided via the `encryption_password` or `encryption_key` arguments will be used to unlock the device and then it will be removed from the LUKS device after the binding operation completes, i.e. it will not be valid anymore. To be used if device has been previously created with a dummy password or passphrase (for example by an automated install like kickstart that set up some sort of "default" password), which the role should replace by a stronger one. |
 
 
 Example:
 ```yaml
 nbde_client_bindings:
   - device: /dev/sda1
-    key_file: /vault/keyfile
+    encryption_key_src: /vault/keyfile
     state: present
     slot: 2
     threshold: 1
-    passphrase_temporary: no
+    password_temporary: no
     servers:
       - http://server1.example.com
       - http://server2.example.com
@@ -68,9 +68,9 @@ Example Playbooks
   vars:
     nbde_client_bindings:
       - device: /dev/sda1
-        # recommend vault encrypting the passphrase
+        # recommend vault encrypting the encryption_password
         # see https://docs.ansible.com/ansible/latest/user_guide/vault.html
-        passphrase: password
+        encryption_password: password
         servers:
           - http://server1.example.com
           - http://server2.example.com
@@ -85,9 +85,9 @@ Example Playbooks
   vars:
     nbde_client_bindings:
       - device: /dev/sda1
-        # recommend vault encrypting the passphrase
+        # recommend vault encrypting the encryption_password
         # see https://docs.ansible.com/ansible/latest/user_guide/vault.html
-        passphrase: password
+        encryption_password: password
         slot: 2
         state: absent
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,11 +9,11 @@ nbde_client_provider: clevis
 # Example:
 # nbde_client_bindings:
 #    - device: /dev/sda1
-#      key_file: /vault/keyfile
+#      encryption_key_src: /vault/keyfile
 #      state: present
 #      slot: 2
 #      threshold: 1
-#      passphrase_temporary: no
+#      password_temporary: no
 #      servers:
 #        - http://server1.example.com
 #        - http://server2.example.com

--- a/examples/high_availability.yml
+++ b/examples/high_availability.yml
@@ -4,9 +4,9 @@
   vars:
     nbde_client_bindings:
       - device: /dev/sda1
-        # recommend vault encrypting the passphrase
+        # recommend vault encrypting the encryption_password
         # see https://docs.ansible.com/ansible/latest/user_guide/vault.html
-        passphrase: password
+        encryption_password: password
         servers:
           - http://server1.example.com
           - http://server2.example.com

--- a/examples/remove_binding.yml
+++ b/examples/remove_binding.yml
@@ -4,9 +4,9 @@
   vars:
     nbde_client_bindings:
       - device: /dev/sda1
-        # recommend vault encrypting the passphrase
+        # recommend vault encrypting the encryption_password
         # see https://docs.ansible.com/ansible/latest/user_guide/vault.html
-        passphrase: password
+        encryption_password: password
         slot: 2
         state: absent
 

--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -17,22 +17,22 @@
     - name: Create temporary directory to hold key files
       tempfile:
         state: directory
-        suffix: nbde_client_key_files
+        suffix: nbde_client_encryption_keys
       when:
         - nbde_client_bindings | default([])
       register: nbde_client_tempdir
 
     - name: Ensure we transfer key files
       copy:
-        src: "{{ item.key_file }}"
+        src: "{{ item.encryption_key_src }}"
         dest: "{{ nbde_client_tempdir.path }}/"
         mode: '0400'
       when:
         - nbde_client_tempdir.path is defined
-        - item.key_file | default("")
+        - item.encryption_key_src | default("")
       loop: "{{ nbde_client_bindings }}"
       loop_control:
-        label: "{{ item.key_file | default('') }}"
+        label: "{{ item.encryption_key_src | default('') }}"
 
     - name: Perform clevis operations
       when:

--- a/tests/tasks/cleanup_test.yml
+++ b/tests/tasks/cleanup_test.yml
@@ -6,13 +6,13 @@
 
 - name: Clean up dummy key file
   file:
-    path: "{{ nbde_client_test_key_file }}"
+    path: "{{ nbde_client_test_encryption_key_src }}"
     state: absent
   delegate_to: localhost
 
 - name: Clean up dummy key file on managed host
   file:
-    path: "{{ nbde_client_test_key_file }}"
+    path: "{{ nbde_client_test_encryption_key_src }}"
     state: absent
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tasks/setup_test.yml
+++ b/tests/tasks/setup_test.yml
@@ -43,7 +43,8 @@
 
 - name: Create key file for test device
   shell: >
-    echo -n {{ nbde_client_test_pass }} > {{ nbde_client_test_key_file }}
+    echo -n {{ nbde_client_test_pass }} >
+    {{ nbde_client_test_encryption_key_src }}
   delegate_to: localhost
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tasks/verify_default_key_file.yml
+++ b/tests/tasks/verify_default_key_file.yml
@@ -2,8 +2,8 @@
 - name: Verify the default key file works
   command: >
     cryptsetup open --test-passphrase "{{ nbde_client_test_device }}"
-    --key-file "{{ nbde_client_test_key_file }}"
+    --key-file "{{ nbde_client_test_encryption_key_src }}"
   ignore_errors: yes
-  register: nbde_client_key_file
+  register: nbde_client_encryption_key
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_bind_high_availability.yml
+++ b/tests/tests_bind_high_availability.yml
@@ -4,7 +4,7 @@
   vars:
     nbde_client_bindings:
       - device: "{{ nbde_client_test_device }}"
-        passphrase: "{{ nbde_client_test_pass }}"
+        encryption_password: "{{ nbde_client_test_pass }}"
         servers:
           - http://localhost
           - http://localhost

--- a/tests/tests_key_rotation.yml
+++ b/tests/tests_key_rotation.yml
@@ -4,7 +4,7 @@
   vars:
     nbde_client_bindings:
       - device: "{{ nbde_client_test_device }}"
-        passphrase: "{{ nbde_client_test_pass }}"
+        encryption_password: "{{ nbde_client_test_pass }}"
         servers:
           - http://localhost
 

--- a/tests/tests_passphrase_temporary.yml
+++ b/tests/tests_passphrase_temporary.yml
@@ -4,8 +4,8 @@
   vars:
     nbde_client_bindings:
       - device: "{{ nbde_client_test_device }}"
-        passphrase: "{{ nbde_client_test_pass }}"
-        passphrase_temporary: yes
+        encryption_password: "{{ nbde_client_test_pass }}"
+        password_temporary: yes
         servers:
           - http://localhost
       - device: "{{ nbde_client_test_device }}"

--- a/tests/tests_passphrase_temporary_keyfile.yml
+++ b/tests/tests_passphrase_temporary_keyfile.yml
@@ -4,8 +4,8 @@
   vars:
     nbde_client_bindings:
       - device: "{{ nbde_client_test_device }}"
-        key_file: "{{ nbde_client_test_key_file }}"
-        passphrase_temporary: yes
+        encryption_key_src: "{{ nbde_client_test_encryption_key_src }}"
+        password_temporary: yes
         servers:
           - http://localhost
       - device: "{{ nbde_client_test_device }}"
@@ -33,8 +33,8 @@
 
         - name: copy the key file to the managed host
           copy:
-            src: "{{ nbde_client_test_key_file }}"
-            dest: "{{ nbde_client_test_key_file }}"
+            src: "{{ nbde_client_test_encryption_key_src }}"
+            dest: "{{ nbde_client_test_encryption_key_src }}"
 
         - name: Attempt to check whether default key file works
           include_tasks: tasks/verify_default_key_file.yml
@@ -42,8 +42,8 @@
         - name: Make sure the default key file did not work
           assert:
             that:
-              - nbde_client_key_file is not success
-              - nbde_client_key_file.stderr ==
+              - nbde_client_encryption_key is not success
+              - nbde_client_encryption_key.stderr ==
                 "No key available with this passphrase."
 
         - name: Assert idempotency

--- a/tests/tests_simple_bind.yml
+++ b/tests/tests_simple_bind.yml
@@ -4,7 +4,7 @@
   vars:
     nbde_client_bindings:
       - device: "{{ nbde_client_test_device }}"
-        passphrase: "{{ nbde_client_test_pass }}"
+        encryption_password: "{{ nbde_client_test_pass }}"
         servers:
           - http://localhost
 

--- a/tests/tests_simple_bind_keyfile.yml
+++ b/tests/tests_simple_bind_keyfile.yml
@@ -4,7 +4,7 @@
   vars:
     nbde_client_bindings:
       - device: "{{ nbde_client_test_device }}"
-        key_file: "{{ nbde_client_test_key_file }}"
+        encryption_key_src: "{{ nbde_client_test_encryption_key_src }}"
         servers:
           - http://localhost
 

--- a/tests/tests_simple_bind_unbind.yml
+++ b/tests/tests_simple_bind_unbind.yml
@@ -4,11 +4,11 @@
   vars:
     nbde_client_bindings:
       - device: "{{ nbde_client_test_device }}"
-        passphrase: "{{ nbde_client_test_pass }}"
+        encryption_password: "{{ nbde_client_test_pass }}"
         servers:
           - http://localhost
       - device: "{{ nbde_client_test_device }}"
-        passphrase: "{{ nbde_client_test_pass }}"
+        encryption_password: "{{ nbde_client_test_pass }}"
         state: absent
 
   tasks:
@@ -35,7 +35,7 @@
           vars:
             nbde_client_bindings:
               - device: "{{ nbde_client_test_device }}"
-                passphrase: "{{ nbde_client_test_pass }}"
+                encryption_password: "{{ nbde_client_test_pass }}"
                 state: absent
 
       always:

--- a/tests/tests_simple_bind_unbind_keyfile.yml
+++ b/tests/tests_simple_bind_unbind_keyfile.yml
@@ -4,11 +4,11 @@
   vars:
     nbde_client_bindings:
       - device: "{{ nbde_client_test_device }}"
-        key_file: "{{ nbde_client_test_key_file }}"
+        encryption_key_src: "{{ nbde_client_test_encryption_key_src }}"
         servers:
           - http://localhost
       - device: "{{ nbde_client_test_device }}"
-        key_file: "{{ nbde_client_test_key_file }}"
+        encryption_key_src: "{{ nbde_client_test_encryption_key_src }}"
         state: absent
 
   tasks:
@@ -35,7 +35,7 @@
           vars:
             nbde_client_bindings:
               - device: "{{ nbde_client_test_device }}"
-                key_file: "{{ nbde_client_test_key_file }}"
+                encryption_key_src: "{{ nbde_client_test_encryption_key_src }}"
                 state: absent
 
       always:

--- a/tests/tests_use_existing_binding.yml
+++ b/tests/tests_use_existing_binding.yml
@@ -13,12 +13,12 @@
           vars:
             nbde_client_bindings:
               - device: "{{ nbde_client_test_device }}"
-                passphrase: "{{ nbde_client_test_pass }}"
+                encryption_password: "{{ nbde_client_test_pass }}"
                 slot: 1
                 servers:
                   - http://localhost
 
-        - name: Add binding to slot 2 without providing passphrase
+        - name: Add binding to slot 2 without providing encryption_password
           include_role:
             name: linux-system-roles.nbde_client
           vars:
@@ -83,7 +83,7 @@
             path: "{{ nbde_client_temp_adv.path }}"
             state: absent
 
-        - name: Add binding to slot 2 without providing passphrase
+        - name: Add binding to slot 2 without providing encryption_password
           include_role:
             name: linux-system-roles.nbde_client
           vars:

--- a/tests/vars/main.yml
+++ b/tests/vars/main.yml
@@ -4,7 +4,7 @@
 
 nbde_client_test_device: /tmp/.nbde_client_dev_test
 nbde_client_test_pass: test-password-here
-nbde_client_test_key_file: /tmp/.nbde_client_dev_key_file
+nbde_client_test_encryption_key_src: /tmp/.nbde_client_dev_encryption_key
 nbde_client_test_roles_dir: /tmp/.nbde_client_dev_roles
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
use `encryption_key_src` instead of `key_file`
use `encryption_password` instead of `passphrase`
use `password_temporary` instead of `passphrase_temporary`