### PR TITLE
fix temp pass key test

### DIFF
--- a/tests/tasks/cleanup_test.yml
+++ b/tests/tasks/cleanup_test.yml
@@ -10,4 +10,9 @@
     state: absent
   delegate_to: localhost
 
+- name: Clean up dummy key file on managed host
+  file:
+    path: "{{ nbde_client_test_key_file }}"
+    state: absent
+
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_passphrase_temporary_keyfile.yml
+++ b/tests/tests_passphrase_temporary_keyfile.yml
@@ -31,6 +31,11 @@
               - not nbde_client_unlock.failed
               - not nbde_client_close.failed
 
+        - name: copy the key file to the managed host
+          copy:
+            src: "{{ nbde_client_test_key_file }}"
+            dest: "{{ nbde_client_test_key_file }}"
+
         - name: Attempt to check whether default key file works
           include_tasks: tasks/verify_default_key_file.yml
 
@@ -38,6 +43,8 @@
           assert:
             that:
               - nbde_client_key_file is not success
+              - nbde_client_key_file.stderr ==
+                "No key available with this passphrase."
 
         - name: Assert idempotency
           include_tasks: tasks/verify_idempotency.yml


### PR DESCRIPTION
The test needs to copy the original temporary key file to the
managed host to see if it can still be used to unlock.  Check
that the error returned from verify is the error that says
the key did not work.