### PR TITLE
The module parameter name is "bindings" with no role prefix

### DIFF
--- a/library/nbde_client_clevis.py
+++ b/library/nbde_client_clevis.py
@@ -35,7 +35,7 @@ description:
     - "Module manages clevis bindings on encryped devices to match the state
        specified in input parameters.
 options:
-    nbde_client_bindings:
+    bindings:
         description:
             - a list of dictionaries that describe a binding that should be
               either added or removed from a given device/slot. It supports


### PR DESCRIPTION
The module parameter name for the list of bindings is just `bindings`
with no `nbde_client_` prefix.

This isn't critical as the module isn't part of the public interface.