### PR TITLE
use tox for ansible-lint instead of molecule

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
           toxenvs="py${toxpyver}"
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint,custom" ;;
-          36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck,custom,collection" ;;
+          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection" ;;
           37) toxenvs="${toxenvs},coveralls,custom" ;;
           38) toxenvs="${toxenvs},coveralls,custom" ;;
           esac

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,6 +6,7 @@ driver:
   name: docker
 lint:
   name: yamllint
+  enabled: false
   options:
     config-file: .yamllint.yml
 platforms:
@@ -18,6 +19,7 @@ provisioner:
   name: ansible
   log: true
   lint:
+    enabled: false
     name: ansible-lint
   playbooks:
     converge: ../../tests/tests_default.yml
@@ -34,3 +36,4 @@ verifier:
   name: testinfra
   lint:
     name: flake8
+    enabled: false

--- a/tests/tasks/setup_test.yml
+++ b/tests/tasks/setup_test.yml
@@ -22,7 +22,7 @@
     name: "{{ nbde_client_test_packages }}"
 
 - name: Clone nbde_server role for the tests
-  git:
+  git:  # noqa 401 - we want to use latest here
     repo: https://github.com/linux-system-roles/nbde_server
     dest: "{{ nbde_client_test_roles_dir }}/linux-system-roles.nbde_server"
   delegate_to: localhost
@@ -34,17 +34,20 @@
 
 - name: Create device for testing
   command: fallocate -l64m {{ nbde_client_test_device }}
+  changed_when: false
 
 - name: Format test device as LUKS
   shell: >
     echo -n {{ nbde_client_test_pass }} |
     cryptsetup luksFormat --pbkdf pbkdf2 --pbkdf-force-iterations 1000
     --batch-mode --force-password {{ nbde_client_test_device }}
+  changed_when: false
 
 - name: Create key file for test device
   shell: >
     echo -n {{ nbde_client_test_pass }} >
     {{ nbde_client_test_encryption_key_src }}
   delegate_to: localhost
+  changed_when: false
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tasks/verify_default_key_file.yml
+++ b/tests/tasks/verify_default_key_file.yml
@@ -4,6 +4,7 @@
     cryptsetup open --test-passphrase "{{ nbde_client_test_device }}"
     --key-file "{{ nbde_client_test_encryption_key_src }}"
   ignore_errors: yes
+  changed_when: false
   register: nbde_client_encryption_key
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tasks/verify_default_passphrase.yml
+++ b/tests/tasks/verify_default_passphrase.yml
@@ -4,6 +4,7 @@
     echo -n "{{ nbde_client_test_pass }}" |
     cryptsetup open --test-passphrase "{{ nbde_client_test_device }}"
   ignore_errors: yes
+  changed_when: false
   register: nbde_client_passphrase
 
 # vim:set ts=2 sw=2 et:

--- a/tests/tasks/verify_unlock_device.yml
+++ b/tests/tasks/verify_unlock_device.yml
@@ -4,11 +4,13 @@
     clevis luks unlock -d "{{ nbde_client_test_device }}"
     -n nbde_client_unlocked
   ignore_errors: yes
+  changed_when: false
   register: nbde_client_unlock
 
 - name: Close unlocked device
   command: cryptsetup close nbde_client_unlocked
   ignore_errors: yes
+  changed_when: false
   register: nbde_client_close
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Deprecate the use of molecule for linting.  Use tox for ansible-lint.
The next step will be to remove the ansible-lint dependency from
the molecule environments.