### PR TITLE
CI: Add support for RHEL-9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
       versions:
         - 7
         - 8
+        - 9
 
   galaxy_tags:
     - centos

--- a/tests/vars/RedHat_9.yml
+++ b/tests/vars/RedHat_9.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+---
+# Put tests variables here with Red Hat Enterprise Linux 9 specific values.
+
+nbde_client_test_packages:
+  - cryptsetup
+
+# vim:set ts=2 sw=2 et:

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 9 specific values.
+
+__nbde_client_packages:
+  - clevis
+  - clevis-dracut
+  - clevis-luks
+  - clevis-systemd
+
+__nbde_client_initramfs_update_cmd: dracut -f
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
From now the `rhel-8-y` status is the latest unreleased RHEL-8 and the `rhel-x` status is pre-released RHEL-9.