### PR TITLE
Do not merge. CI: Check the default RAM/memory size for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 nbde_client
 -----------
 ![CI Testing](https://github.com/linux-system-roles/nbde_client/workflows/tox/badge.svg)


### PR DESCRIPTION
We use newer standard-inventory-qcow2. Test the memory size for EL distributions.