### PR TITLE
README.md - Adding a blank line after nbde_client_bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ These are the variables that can be passed to the role:
 
 
 #### nbde_client_bindings
+
 `nbde_client_bindings` is a list of dictionaries that support the following keys:
+
 | **Name** | **Default/Choices** | **Description** |
 |----------|-------------|------|
 | `device` | | specifies the path of the backing device of an encrypted device on the managed host. This device must be already configured as a LUKS device before using the role (**REQUIRED**). |


### PR DESCRIPTION
Some markdown renderer does not process the file properly if there's no blank line between a header, a table, etc.
E.g.,
```
#### nbde_client_bindings
 `nbde_client_bindings` is a list of dictionaries that support the following keys:
 | **Name** | **Default/Choices** | **Description** |
|----------|-------------|------|
| `device` | | specifies the path of the ...
```
==>
`+nbde_client_bindings+ is a list of dictionaries that support the following keys: | Name | Default/Choices | Description | |----------|-------------|------| | +device+ | | specifies the path of the ...`.
By adding a blank line between the header/table and the ordinary line, it's processed properly.