### PR TITLE
add regenerate-all to the dracut command 

### DIFF
--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -8,6 +8,7 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
 
-__nbde_client_initramfs_update_cmd: dracut -f
+
+__nbde_client_initramfs_update_cmd: dracut -f --regenerate-all
 
 # vim:set ts=2 sw=2 et:

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -9,6 +9,6 @@ __nbde_client_packages:
   - clevis-systemd
 
 
-__nbde_client_initramfs_update_cmd: dracut -f --regenerate-all
+__nbde_client_initramfs_update_cmd: dracut -fv --regenerate-all --hostonly-cmdline
 
 # vim:set ts=2 sw=2 et:

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -8,6 +8,6 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
 
-__nbde_client_initramfs_update_cmd: dracut -f --regenerate-all
+__nbde_client_initramfs_update_cmd: dracut -fv --regenerate-all --hostonly-cmdline
 
 # vim:set ts=2 sw=2 et:

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -8,6 +8,6 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
 
-__nbde_client_initramfs_update_cmd: dracut -f
+__nbde_client_initramfs_update_cmd: dracut -f --regenerate-all
 
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -8,6 +8,6 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
 
-__nbde_client_initramfs_update_cmd: dracut -f --regenerate-all
+__nbde_client_initramfs_update_cmd: dracut -fv --regenerate-all --hostonly-cmdline
 
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -8,6 +8,6 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
 
-__nbde_client_initramfs_update_cmd: dracut -f
+__nbde_client_initramfs_update_cmd: dracut -f --regenerate-all
 
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -8,6 +8,6 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
 
-__nbde_client_initramfs_update_cmd: dracut -f --regenerate-all
+__nbde_client_initramfs_update_cmd: dracut -fv --regenerate-all --hostonly-cmdline
 
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -8,6 +8,6 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
 
-__nbde_client_initramfs_update_cmd: dracut -f
+__nbde_client_initramfs_update_cmd: dracut -f --regenerate-all
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening#configuring-manual-enrollment-of-volumes-using-clevis_configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption

section 9.9 point 5 recommends using dracut -f plus --regenerate-all sometimes the systems can not be booted 