### PR TITLE
Add dracut module for disabling autoconnect within initrd

### DIFF
--- a/files/nbde_client-network-flush
+++ b/files/nbde_client-network-flush
@@ -1,8 +1,13 @@
 #!/bin/sh
 
+# This script flushes every active network interface. It is intended to
+# run before NetworkManager starts, so that when it does it will be able
+# to set up the network using the regular host configuration.
+
 for f in /sys/class/net/*; do
   iface="${f##*/}"
   [ "${iface}" = "lo" ] && continue
+  echo "Preparing to flush interface ${iface}" >&2
   ip -statistics address flush dev "${iface}"
 done
 

--- a/files/nbde_client/module-setup.sh
+++ b/files/nbde_client/module-setup.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+depends() {
+  echo network-manager
+  return 255
+}
+
+install() {
+  inst_multiple nmcli grep cut
+
+  # $moddir is a dracut variable.
+  # shellcheck disable=SC2154
+  inst_hook initqueue/online 60 "$moddir/nbde_client-hook.sh"
+  inst_hook initqueue/settled 60 "$moddir/nbde_client-hook.sh"
+}
+
+# vim:set ts=2 sw=2 et:

--- a/files/nbde_client/nbde_client-hook.sh
+++ b/files/nbde_client/nbde_client-hook.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# disable_inird_connections() will disable autoconnect for the active
+# connections within the initramfs, so that these will not clash with
+# the system network connections once the flush is performed and
+# the network configuration is applied to the system.
+disable_inird_connections() {
+  nmcli -t -f NAME connection show --active | while read -r _c; do
+  if ! _enabled="$(nmcli -t connection show "${_c}" \
+             | grep connection.autoconnect: \
+             | cut -d: -f2)" || [ -z "${_enabled}" ]; then
+    continue
+  fi
+  [ "${_enabled}" = "no" ] && continue
+
+  echo "[nbde_client] Disabling autoconnect for connection ${_c}" >&2
+  nmcli connection modify "${_c}" connection.autoconnect no
+  done
+}
+
+disable_inird_connections
+
+# vim:set ts=2 sw=2 et:

--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -82,6 +82,13 @@
         dest: /etc/systemd/system/nbde_client-network-flush.service
         mode: '0644'
 
+    - name: Deploy nbde_client dracut network flushing module
+      copy:
+        src: "{{ role_path }}/files/nbde_client/"
+        dest: /usr/lib/dracut/modules.d/60nbde_client/
+        directory_mode: '0755'
+        mode: '0644'
+
     - name: Reload systemd config
       systemd:
         daemon_reload: yes

--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -8,6 +8,7 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
   - iproute
+  - NetworkManager
 
 __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all

--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -14,6 +14,6 @@ __nbde_client_initramfs_update_cmd: >
 
 __nbde_client_dracut_settings:
   - kernel_cmdline="rd.neednet=1"
-  - omit_dracutmodules+="ifcfg"
+  - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -8,6 +8,7 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
   - iproute
+  - NetworkManager
 
 __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -14,6 +14,6 @@ __nbde_client_initramfs_update_cmd: >
 
 __nbde_client_dracut_settings:
   - kernel_cmdline="rd.neednet=1"
-  - omit_dracutmodules+="ifcfg"
+  - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -8,6 +8,7 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
   - iproute
+  - NetworkManager
 
 __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -14,6 +14,6 @@ __nbde_client_initramfs_update_cmd: >
 
 __nbde_client_dracut_settings:
   - kernel_cmdline="rd.neednet=1"
-  - omit_dracutmodules+="ifcfg"
+  - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -8,6 +8,7 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
   - iproute
+  - NetworkManager
 
 __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -14,6 +14,6 @@ __nbde_client_initramfs_update_cmd: >
 
 __nbde_client_dracut_settings:
   - kernel_cmdline="rd.neednet=1"
-  - omit_dracutmodules+="ifcfg"
+  - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -8,6 +8,7 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
   - iproute
+  - NetworkManager
 
 __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -14,6 +14,6 @@ __nbde_client_initramfs_update_cmd: >
 
 __nbde_client_dracut_settings:
   - kernel_cmdline="rd.neednet=1"
-  - omit_dracutmodules+="ifcfg"
+  - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -8,6 +8,7 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
   - iproute
+  - NetworkManager
 
 __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -14,6 +14,6 @@ __nbde_client_initramfs_update_cmd: >
 
 __nbde_client_dracut_settings:
   - kernel_cmdline="rd.neednet=1"
-  - omit_dracutmodules+="ifcfg"
+  - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -8,6 +8,7 @@ __nbde_client_packages:
   - clevis-luks
   - clevis-systemd
   - iproute
+  - NetworkManager
 
 __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -14,6 +14,6 @@ __nbde_client_initramfs_update_cmd: >
 
 __nbde_client_dracut_settings:
   - kernel_cmdline="rd.neednet=1"
-  - omit_dracutmodules+="ifcfg"
+  - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
The network connection created during the initramfs for unlocking the
device may conflict with the actual system connection later on, when
the system attempts to configure the network as per the regular
configuration, after the boot process has completed.

To prevent this situation, we now deploy a dracut module to disable
autoconnect of the network connectons that are active during the
initramfs.