### PR TITLE
network-flush: reset autoconnect-priority to zero

### DIFF
--- a/files/nbde_client-network-flush
+++ b/files/nbde_client-network-flush
@@ -1,14 +1,37 @@
 #!/bin/sh
 
-# This script flushes every active network interface. It is intended to
+# do_flush() flushes every active network interface. It is intended to
 # run before NetworkManager starts, so that when it does it will be able
 # to set up the network using the regular host configuration.
+do_flush() {
+  for f in /sys/class/net/*; do
+    iface="${f##*/}"
+    [ "${iface}" = "lo" ] && continue
+    echo "Preparing to flush interface ${iface}" >&2
+    ip -statistics address flush dev "${iface}"
+  done
+}
 
-for f in /sys/class/net/*; do
-  iface="${f##*/}"
-  [ "${iface}" = "lo" ] && continue
-  echo "Preparing to flush interface ${iface}" >&2
-  ip -statistics address flush dev "${iface}"
-done
+# reset_autoconn_prio() will reset the autoconnect priority
+# of the existing NM connections to zero.
+reset_autoconn_prio() {
+  nmcli -t -f NAME connection show 2>/dev/null | while read -r _c; do
+    if ! _prio="$(nmcli -t connection show "${_c}" \
+           | grep connection.autoconnect-priority: \
+           | cut -d: -f2)" || [ -z "${_prio}" ]; then
+      continue
+    fi
+    [ "${_prio}" -ge 0 ] && continue
+    echo "Setting autoconnect-priority of connection ${_c} to zero" >&2
+    nmcli connection modify "${_c}" connection.autoconnect-priority 0
+  done
+}
+
+case "${1}" in
+reset-autoconn-prio)
+  reset_autoconn_prio;;
+flush)
+  do_flush;;
+esac
 
 # vim:set ts=2 sw=2 et:

--- a/files/nbde_client-network-flush.service
+++ b/files/nbde_client-network-flush.service
@@ -4,7 +4,7 @@ Before=network-pre.target
 Wants=network-pre.target
 
 [Service]
-ExecStart=/usr/bin/nbde_client-network-flush
+ExecStart=/usr/bin/nbde_client-network-flush flush
 
 [Install]
 WantedBy=default.target

--- a/files/nbde_client/nbde_client-hook.sh
+++ b/files/nbde_client/nbde_client-hook.sh
@@ -5,7 +5,7 @@
 # the system network connections once the flush is performed and
 # the network configuration is applied to the system.
 disable_inird_connections() {
-  nmcli -t -f NAME connection show --active | while read -r _c; do
+  nmcli -t -f NAME connection show --active 2>/dev/null | while read -r _c; do
   if ! _enabled="$(nmcli -t connection show "${_c}" \
              | grep connection.autoconnect: \
              | cut -d: -f2)" || [ -z "${_enabled}" ]; then

--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -89,6 +89,12 @@
         directory_mode: '0755'
         mode: '0644'
 
+    - name: Prepare for network flushing - reset autoconnect-priority
+      ansible.builtin.command:
+        cmd: /usr/bin/nbde_client-network-flush reset-autoconn-prio
+      register: __nbde_client_autoconn_prio
+      changed_when: __nbde_client_autoconn_prio.stderr
+
     - name: Reload systemd config
       systemd:
         daemon_reload: yes


### PR DESCRIPTION
With older dracut, where NetworkManager does not run as a daemon
and with dbus, the dracut module we have will not work to disable
autoconnect for the connections created within the initramfs, which
may be a problem as after the network flush, NM will activate the
connection with the higher priority, and the initramfs connection
may be it.

Some connections are created with negative priority, by e.g. the
Anaconda installer, which may be a problem in this situation. To
work around this issue, we now reset the autoconnect priority of
the connections to zero.