### PR TITLE
Sets needed spacing for appended rd.neednet parameter

### DIFF
--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -14,7 +14,7 @@ __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all
 
 __nbde_client_dracut_settings:
-  - kernel_cmdline="rd.neednet=1"
+  - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -14,7 +14,7 @@ __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all
 
 __nbde_client_dracut_settings:
-  - kernel_cmdline="rd.neednet=1"
+  - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -14,7 +14,7 @@ __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all
 
 __nbde_client_dracut_settings:
-  - kernel_cmdline="rd.neednet=1"
+  - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -14,7 +14,7 @@ __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all
 
 __nbde_client_dracut_settings:
-  - kernel_cmdline="rd.neednet=1"
+  - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -14,7 +14,7 @@ __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all
 
 __nbde_client_dracut_settings:
-  - kernel_cmdline="rd.neednet=1"
+  - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -14,7 +14,7 @@ __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all
 
 __nbde_client_dracut_settings:
-  - kernel_cmdline="rd.neednet=1"
+  - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -14,7 +14,7 @@ __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all
 
 __nbde_client_dracut_settings:
-  - kernel_cmdline="rd.neednet=1"
+  - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
In our limited testing, we've found that the appended rd.neednet parameter needs to have proper spacing between the quotes.  I.E.  kernel_cmdline+= " rd.neednet=1 " so that it's properly appended to the kernel command line.  

When using a static IP, if the rd.neednet parameter does not have proper spacing, adapter link does not appear to be brought up.  These commits modify the vars yaml file for each distro to use the spaced out parameter.  Also changes = to += for the append operation.