### PR TITLE
correct clevis askpass unit conditional

### DIFF
--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -4,13 +4,14 @@
     name: "{{ __nbde_client_packages }}"
     state: present
 
+- name: Get services
+  service_facts:
+
 - name: Enable clevis askpass unit
   service:
     name: clevis-luks-askpass.path
     enabled: yes
-  when: ansible_distribution != "RedHat" or
-    (not ansible_distribution_version is version("8.2", "==") and
-     not ansible_distribution_version is version("8.3", "=="))
+  when: ansible_facts.services['clevis-luks-askpass.service'] is defined
 
 - name: Generate nbde_client dracut config
   template:


### PR DESCRIPTION
A bug was introduced in PR [Add default clevis luks askpass unit #79](https://github.com/linux-system-roles/nbde_client/pull/79) which silently fails to configure the clevis askpass unit correctly on RHEL 8.2 and 8.3 with certain versions of the `clevis-systemd` package installed. This PR fixes it by changing the conditional such that if the `clevis-luks-askpass.path` service exists, it is enabled. If it doesn't exist, then a version of `clevis-systemd` that uses templated units is installed, and the unit will be enabled by `dracut`. Tests have been successful with templated, and static `clevis-luks-askpass.path` units.