### PR TITLE
Use tox-lsr 2.13.1; force the use of tox 3.x [citest skip]

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default


### PR DESCRIPTION
CI is broken pretty hard right now due to tox 4.x being released
It will take non-trivial effort to make tox-lsr work with tox 4.x. So,
in the meantime, tox-lsr 2.13.1 forces the use of tox 3.x

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
