### PR TITLE
Add check for non-inclusive language

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,18 @@
+# yamllint disable rule:line-length
+name: Check for non-inclusive language
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml"
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,14 +64,11 @@ temp directory for controller files.
 
 ### Other Changes
 
-- changelog_to_tag action - support other than "master" for the main branch name, as well (#75)
+- changelog_to_tag action - github action ansible test improvements
 
 - Use GITHUB_REF_NAME as name of push branch; fix error in branch detection [citest skip] (#76)
 
 We need to get the name of the branch to which CHANGELOG.md was pushed.
-For now, it looks as though `GITHUB_REF_NAME` is that name.  But don't
-trust it - first, check that it is `main` or `master`.  If not, then use
-a couple of other methods to determine what is the push branch.
 
 Signed-off-by: Rich Megginson <rmeggins@redhat.com>
 
@@ -254,7 +251,7 @@ must be a `string` value like `"2.9"`, not a `float` value like `2.9`.
 
 - Remove python-26 environment from tox testing
 - README.md - Adding a blank line after nbde\_client\_bindings
-- update to tox-lsr 2.4.0 - add support for ansible-test sanity with docker
+- update to tox-lsr 2.4.0 - add support for ansible-test with docker
 - Increase memory of tests
 - CI: Add support for RHEL-9
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ These are the variables that can be passed to the role:
 | `slot` | `1` | specifies the slot to use for the binding. |
 | `servers` | |  specifies a list of servers to bind to. To enable high availability, specify more than one server here. |
 | `threshold` | `1` | specifies the threshold for the Shamir Secret Sharing (SSS) scheme that is put in place when using more than one server. When using multiple servers, threshold indicates how many of those servers should succeed, in terms of decryption, in order to complete the process of recovering the LUKS passphrase to open the device. |
-| `password_temporary` | `no` | If yes, the password or passphrase that was provided via the `encryption_password` or `encryption_key` arguments will be used to unlock the device and then it will be removed from the LUKS device after the binding operation completes, i.e. it will not be valid anymore. To be used if device has been previously created with a dummy password or passphrase (for example by an automated install like kickstart that set up some sort of "default" password), which the role should replace by a stronger one. |
+| `password_temporary` | `no` | If yes, the password or passphrase that was provided via the `encryption_password` or `encryption_key` arguments will be used to unlock the device and then it will be removed from the LUKS device after the binding operation completes, i.e. it will not be valid anymore. To be used if device has been previously created with a sample password or passphrase (for example by an automated install like kickstart that set up some sort of "default" password), which the role should replace by a stronger one. |
 
 
 Example:

--- a/library/nbde_client_clevis.py
+++ b/library/nbde_client_clevis.py
@@ -999,7 +999,9 @@ def unbind_slot(module, device, slot):
 
 
 def new_key(module, device):
-    """Generate a new key with the same entropy as the LUKS master key.
+    """
+    wokeignore:rule=master
+    Generate a new key with the same entropy as the LUKS master key.
     Return <key> <error>"""
 
     luks, err = get_luks_type(module, device)
@@ -1432,8 +1434,8 @@ def already_bound(module, **kwargs):
     return True
 
 
-def bindings_sanity_check(bindings, data_dir, check_mode):
-    """Performs sanity-checking on the bindings list and related arguments.
+def bindings_confidence_check(bindings, data_dir, check_mode):
+    """Performs confidence-checking on the bindings list and related arguments.
     Return: <bindings> <error>"""
 
     # bindings is a list of the following:
@@ -1584,7 +1586,7 @@ def run_module():
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
     params = module.params
 
-    bindings, err = bindings_sanity_check(
+    bindings, err = bindings_confidence_check(
         params["bindings"], params["data_dir"], module.check_mode
     )
 

--- a/tests/tasks/cleanup_test.yml
+++ b/tests/tasks/cleanup_test.yml
@@ -1,5 +1,5 @@
 ---
-- name: Clean up dummy testing device
+- name: Clean up sample testing device
   file:
     path: "{{ nbde_client_test_device }}"
     state: absent


### PR DESCRIPTION
Add a check for usage of terms and language that is considered
non-inclusive. We are using the woke tool for this with a wordlist
that can be found at
https://github.com/linux-system-roles/tox-lsr/blob/main/src/tox_lsr/config_files/woke.yml

Clean up non-inclusive words.    
- CHANGELOG.md
- README.md
- library/nbde_client_clevis.py
- tests/tasks/cleanup_test.yml

Note: `master` is left in nbde_client_clevis.py as follows, which causes the non-inclusive language check action fails.
```
library/nbde_client_clevis.py:    """Generate a new key with the same entropy as the LUKS master key.
```
There are three ways to fix it - 1) replacing `LUKS master key` with a phrase that does not include `master` or 2) leaving `LUKS master key` as it is and applying https://github.com/get-woke/woke/pull/252 that allows the warning level severity or 3) ignoring "the LUKS master key" by wokeignore:rule=master.

I've updated the pr using (3) as seen at https://github.com/linux-system-roles/nbde_client/pull/91/files#diff-fcb01b85ce6e35eb2f419f284a8ac712d435336b141a96ec73a2a03edade7f5aR1003, which makes the woke test pass. Is it ok?