### PR TITLE
Use daemon_reload with askpass path service

### DIFF
--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -8,7 +8,7 @@
   service_facts:
 
 - name: Enable clevis askpass unit
-  service:
+  systemd:
     name: clevis-luks-askpass.path
     enabled: true
     daemon_reload: true

--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -11,6 +11,7 @@
   service:
     name: clevis-luks-askpass.path
     enabled: true
+    daemon_reload: true
   when: ansible_facts.services['clevis-luks-askpass.service'] is defined
 
 - name: Generate nbde_client dracut config


### PR DESCRIPTION
Under certain conditions on some platforms, enabling the askpass.path service
will fail with "file not found".  Using `daemon_reload: true` makes it
work.
