### PR TITLE
Fix nbde_client error handling

### DIFF
--- a/library/nbde_client_clevis.py
+++ b/library/nbde_client_clevis.py
@@ -1577,10 +1577,16 @@ def process_bindings(module, bindings):
 
 
 def obscure_sensitive_parameters(result):
-    bindings = result.get("original_bindings", [])
-    for binding in bindings:
-        if "encryption_password" in binding:
-            binding["encryption_password"] = "***"
+    """Find and obscure sensitive data in nested data structures."""
+    if isinstance(result, dict):
+        for kk, vv in list(result.items()):
+            if kk == "encryption_password":
+                result[kk] = "***"
+            else:
+                obscure_sensitive_parameters(vv)
+    elif isinstance(result, list):
+        for item in result:
+            obscure_sensitive_parameters(item)
 
 
 def run_module():

--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -66,6 +66,11 @@
       notify: Handle nbde_client update initramfs
       no_log: true
 
+  rescue:
+    - name: Failed message
+      fail:
+        msg: "{{ ansible_failed_result }}"
+
   always:
     - name: Remove temporary directory used to hold key files
       file:

--- a/tests/tests_error_handling.yml
+++ b/tests/tests_error_handling.yml
@@ -2,8 +2,9 @@
 - name: Test error handling
   hosts: all
   vars:
+    __test_dev: /no/such/path/or/device
     nbde_client_bindings:
-      - device: /no/such/path/or/device
+      - device: "{{ __test_dev }}"
         encryption_password: "{{ nbde_client_test_pass }}"
         servers:
           - http://localhost
@@ -18,19 +19,24 @@
           include_role:
             name: linux-system-roles.nbde_client
       rescue:
+        - name: Extract the result
+          set_fact:
+            __result: "{{ ansible_failed_result
+              if 'original_bindings' in ansible_failed_result
+              else ansible_failed_result.msg }}"
+
         - name: Assert that the error message is correct
           assert:
-            that: ansible_failed_result.msg is search(__errmsg)
+            that: __result.msg is search(__errmsg)
           vars:
-            __errmsg: >-
-              Device /no/such/path/or/device does not exist or access denied.
+            __errmsg: Device {{ __test_dev }} .* exist or access denied.
 
         - name: Assert that the password is obscured
           assert:
             that: __pwd == "***"
           vars:
             __pwfield: encryption_password
-            __pwd: "{{ ansible_failed_result.original_bindings[0][__pwfield] }}"
+            __pwd: "{{ __result.original_bindings[0][__pwfield] }}"
       always:
         - name: Clean up test environment
           include_tasks: tasks/cleanup_test.yml


### PR DESCRIPTION
Because the nbde_client role throws the error in a block/always, the error
must be caught with rescue and rethrown.  See
https://richm.github.io/how-to-catch-and-reraise-errors-in-ansible

The sensitive field might be in a deeply nested data structure, so
iterate through the data structure.

The re-raised error is not in `ansible_failed_result` it is in
`ansible_failed_result.msg`
