### PR TITLE
Create separate github actions for various checks; get rid of monolithic tox.yml

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,11 +1,5 @@
 ---
 profile: production
-skip_list:
-  - fqcn-builtins
-exclude_paths:
-  - tests/roles/
-  - .github/
-  - examples/roles/
 kinds:
   - yaml: "**/meta/collection-requirements.yml"
   - yaml: "**/tests/collection-requirements.yml"
@@ -17,5 +11,11 @@ kinds:
   - tasks: "**/tests/tasks/*/*.yml"
   - vars: "**/tests/vars/*.yml"
   - playbook: "**/examples/*.yml"
+skip_list:
+  - fqcn-builtins
+exclude_paths:
+  - tests/roles/
+  - .github/
+  - examples/roles/
 mock_roles:
   - linux-system-roles.nbde_client

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -5,12 +5,16 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - master
   workflow_dispatch:
 jobs:
   ansible_lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Update pip, git
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y git
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Fix up role meta/main.yml namespace and name

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,29 @@
+---
+name: Ansible Lint
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+jobs:
+  ansible_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Fix up role meta/main.yml namespace and name
+        run: |
+          set -euxo pipefail
+          mm=meta/main.yml
+          if [ -f "$mm" ]; then
+            if ! grep -q '^  *namespace:' "$mm"; then
+              sed "/galaxy_info:/a\  namespace: linux_system_roles" -i "$mm"
+            fi
+            if ! grep -q '^  *role_name:' "$mm"; then
+              sed "/galaxy_info:/a\  role_name: nbde_client" -i "$mm"
+            fi
+          fi
+      - name: Run ansible-lint
+        uses: ansible-community/ansible-lint-action@v6

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -1,0 +1,26 @@
+---
+name: Check for ansible_managed variable use in comments
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+jobs:
+  ansible_managed_var_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install tox, tox-lsr
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          sudo apt-get update
+          sudo apt-get install -y git
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+      - name: Run ansible-plugin-scan
+        run: |
+          set -euxo pipefail
+          TOXENV=ansible-managed-var-comment lsr_ci_runtox

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Update pip, git
         run: |
           set -euxo pipefail
-          python3 -m pip install --upgrade pip3
+          python3 -m pip install --upgrade pip
           sudo apt-get update
           sudo apt-get install -y git
       - name: Checkout repo

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -5,21 +5,23 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - master
   workflow_dispatch:
 jobs:
   ansible_managed_var_comment:
     runs-on: ubuntu-latest
     steps:
+      - name: Update pip, git
+        run: |
+          set -euxo pipefail
+          python3 -m pip install --upgrade pip3
+          sudo apt-get update
+          sudo apt-get install -y git
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          python -m pip install --upgrade pip
-          sudo apt-get update
-          sudo apt-get install -y git
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
       - name: Run ansible-plugin-scan
         run: |
           set -euxo pipefail

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Update pip, git
         run: |
           set -euxo pipefail
-          python3 -m pip install --upgrade pip3
+          python3 -m pip install --upgrade pip
           sudo apt-get update
           sudo apt-get install -y git
       - name: Checkout repo

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -5,21 +5,23 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - master
   workflow_dispatch:
 jobs:
   ansible_plugin_scan:
     runs-on: ubuntu-latest
     steps:
+      - name: Update pip, git
+        run: |
+          set -euxo pipefail
+          python3 -m pip install --upgrade pip3
+          sudo apt-get update
+          sudo apt-get install -y git
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          python -m pip install --upgrade pip
-          sudo apt-get update
-          sudo apt-get install -y git
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
       - name: Run ansible-plugin-scan
         run: |
           set -euxo pipefail

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -1,0 +1,26 @@
+---
+name: Ansible Plugin Scan
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+jobs:
+  ansible_plugin_scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install tox, tox-lsr
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          sudo apt-get update
+          sudo apt-get install -y git
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+      - name: Run ansible-plugin-scan
+        run: |
+          set -euxo pipefail
+          TOXENV=ansible-plugin-scan lsr_ci_runtox

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,0 +1,45 @@
+---
+name: Ansible Test
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+env:
+  LSR_ROLE2COLL_NAMESPACE: fedora
+  LSR_ROLE2COLL_NAME: linux_system_roles
+jobs:
+  ansible_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install tox, tox-lsr
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          sudo apt-get update
+          sudo apt-get install -y git
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+      - name: Convert role to collection format
+        run: |
+          set -euxo pipefail
+          TOXENV=collection lsr_ci_runtox
+          # copy the ignore files
+          coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+          ignore_dir="$coll_dir/tests/sanity"
+          if [ ! -d "$ignore_dir" ]; then
+            mkdir -p "$ignore_dir"
+          fi
+          for file in .sanity-ansible-ignore-*.txt; do
+            if [ -f "$file" ]; then
+              cp "$file" "$ignore_dir/${file//*.sanity-ansible-}"
+            fi
+          done
+      - name: Run ansible-test
+        uses: ansible-community/ansible-test-gh-action@release/v1
+        with:
+          testing-type: sanity
+          collection-src-directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Update pip, git
         run: |
           set -euxo pipefail
-          python3 -m pip install --upgrade pip3
+          python3 -m pip install --upgrade pip
           sudo apt-get update
           sudo apt-get install -y git
       - name: Checkout repo

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -5,7 +5,6 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - master
   workflow_dispatch:
 env:
   LSR_ROLE2COLL_NAMESPACE: fedora
@@ -14,32 +13,38 @@ jobs:
   ansible_test:
     runs-on: ubuntu-latest
     steps:
+      - name: Update pip, git
+        run: |
+          set -euxo pipefail
+          python3 -m pip install --upgrade pip3
+          sudo apt-get update
+          sudo apt-get install -y git
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          python -m pip install --upgrade pip
-          sudo apt-get update
-          sudo apt-get install -y git
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
       - name: Convert role to collection format
         run: |
           set -euxo pipefail
           TOXENV=collection lsr_ci_runtox
           # copy the ignore files
           coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+          # wokeignore:rule=sanity
           ignore_dir="$coll_dir/tests/sanity"
           if [ ! -d "$ignore_dir" ]; then
             mkdir -p "$ignore_dir"
           fi
+          # wokeignore:rule=sanity
           for file in .sanity-ansible-ignore-*.txt; do
             if [ -f "$file" ]; then
+              # wokeignore:rule=sanity
               cp "$file" "$ignore_dir/${file//*.sanity-ansible-}"
             fi
           done
       - name: Run ansible-test
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          testing-type: sanity
+          testing-type: sanity  # wokeignore:rule=sanity
           collection-src-directory: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -5,7 +5,6 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - master
     paths:
       - CHANGELOG.md
 env:
@@ -14,6 +13,11 @@ jobs:
   tag_release_publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Update pip, git
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y git
       - name: checkout PR
         uses: actions/checkout@v3
       - name: Get tag and message from the latest CHANGELOG.md commit

--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -1,5 +1,6 @@
+---
 # yamllint disable rule:line-length
-name: Pushing CHANGELOG.md triggers tag, release, and Galaxy publish
+name: Tag, release, and publish role based on CHANGELOG.md push
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
@@ -14,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get tag and message from the latest CHANGELOG.md commit
         id: tag
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,11 @@ jobs:
       matrix:
         language: [python]
     steps:
+      - name: Update pip, git
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y git
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,12 @@
 ---
-name: "CodeQL"
-
+name: CodeQL
 on:  # yamllint disable-line rule:truthy
   push:
     branches: ["main"]
   pull_request:
     branches: ["main"]
   schedule:
-    - cron: "24 13 * * 2"
-
+    - cron: 24 13 * * 2
 jobs:
   analyze:
     name: Analyze
@@ -17,12 +15,10 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
         language: [python]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -1,31 +1,31 @@
+---
 # yamllint disable rule:line-length
-name: tox
+name: Python Unit Tests
 on:  # yamllint disable-line rule:truthy
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
-  LSR_ANSIBLE_TEST_DOCKER: "true"
-  LSR_ANSIBLES: 'ansible==2.9.*'
-  LSR_MSCENARIOS: default
-  # LSR_EXTRA_PACKAGES: libdbus-1-dev
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   python:
     strategy:
       matrix:
         pyver_os:
-          - ver: '2.7'
+          - ver: "2.7"
             os: ubuntu-20.04
-          - ver: '3.6'
+          - ver: "3.6"
             os: ubuntu-20.04
-          - ver: '3.8'
+          - ver: "3.8"
             os: ubuntu-latest
-          - ver: '3.9'
+          - ver: "3.9"
             os: ubuntu-latest
-          - ver: '3.10'
+          - ver: "3.10"
             os: ubuntu-latest
-          - ver: '3.11'
+          - ver: "3.11"
             os: ubuntu-latest
     runs-on: ${{ matrix.pyver_os.os }}
     steps:
@@ -41,19 +41,25 @@ jobs:
           python -m pip install --upgrade pip
           sudo apt-get update
           sudo apt-get install -y git
-          pip install "$TOX_LSR"
-          lsr_ci_preinstall
-      - name: Run tox tests
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
+          # If you have additional OS dependency packages e.g. libcairo2-dev
+          # then put them in .github/config/ubuntu-requirements.txt, one
+          # package per line.
+          if [ -f .github/config/ubuntu-requirements.txt ]; then
+            sudo apt-get install -y $(cat .github/config/ubuntu-requirements.txt)
+          fi
+      - name: Run unit tests
         run: |
           set -euxo pipefail
           toxpyver=$(echo "${{ matrix.pyver_os.ver }}" | tr -d .)
           toxenvs="py${toxpyver}"
+          # NOTE: The use of flake8, pylint, black with specific
+          # python envs is arbitrary and must be changed in tox-lsr
+          # We really should either do those checks using the latest
+          # version of python, or in every version of python
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint" ;;
-          36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck" ;;
-          38) toxenvs="${toxenvs},coveralls,ansible-lint,ansible-plugin-scan,collection,ansible-test" ;;
-          39) toxenvs="${toxenvs},coveralls,ansible-managed-var-comment" ;;
-          310) toxenvs="${toxenvs},coveralls,check-meta-versions" ;;
-          311) toxenvs="${toxenvs},coveralls" ;;
+          36) toxenvs="${toxenvs},coveralls,black" ;;
+          *) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -6,7 +6,6 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - master
   workflow_dispatch:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -29,6 +28,11 @@ jobs:
             os: ubuntu-latest
     runs-on: ${{ matrix.pyver_os.os }}
     steps:
+      - name: Update git
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y git
       - name: checkout PR
         uses: actions/checkout@v3
       - name: Set up Python
@@ -39,8 +43,6 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          sudo apt-get update
-          sudo apt-get install -y git
           pip install "git+https://github.com/linux-system-roles/tox-lsr@2.13.1"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,7 +5,6 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - master
   workflow_dispatch:
 env:
   # some scripts source tox-lsr scripts - suppress that check
@@ -14,6 +13,11 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
+      - name: Update git
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y git
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Run ShellCheck

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,25 @@
+---
+name: ShellCheck
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+env:
+  # some scripts source tox-lsr scripts - suppress that check
+  SHELLCHECK_OPTS: -e SC1091
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Run ShellCheck
+        id: shellcheck_id
+        uses: ludeeus/action-shellcheck@master
+      - name: Show file paths scanned
+        run: |
+          echo Files scanned:
+          echo "${{ steps.shellcheck_id.outputs.files }}"

--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -16,6 +16,11 @@ jobs:
   weekly_ci:
     runs-on: ubuntu-latest
     steps:
+      - name: Update pip, git
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y git
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -23,26 +28,10 @@ jobs:
         run: |
           set -euxo pipefail
 
-          get_main_branch() {
-              local br
-              br=$(git branch --list main)
-              if [ -n "$br" ]; then
-                  echo main
-                  return 0
-              fi
-              br=$(git branch --list master)
-              if [ -n "$br" ]; then
-                  echo master
-                  return 0
-              fi
-              echo UNKNOWN
-              return 1
-          }
-
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout ${{ env.BRANCH_NAME }} || git checkout -b ${{ env.BRANCH_NAME }}
-          git rebase $(get_main_branch)
+          git rebase main
           git commit --allow-empty -m "${{ env.COMMIT_MESSAGE }}"
           git push -f --set-upstream origin ${{ env.BRANCH_NAME }}
 

--- a/.github/workflows/weekly_ci.yml
+++ b/.github/workflows/weekly_ci.yml
@@ -3,11 +3,14 @@ name: Weekly CI trigger
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
   schedule:
-    - cron: '0 11 * * 6'
+    - cron: 0 11 * * 6
 env:
-  BRANCH_NAME: "weekly-ci"
-  COMMIT_MESSAGE: "This PR is to trigger periodic CI testing"
-  BODY_MESSAGE: "This PR is for the purpose of triggering periodic CI testing. We don't currently have a way to trigger CI without a PR, so this PR serves that purpose."
+  BRANCH_NAME: weekly-ci
+  COMMIT_MESSAGE: This PR is to trigger periodic CI testing
+  BODY_MESSAGE: >-
+    This PR is for the purpose of triggering periodic CI testing.
+    We don't currently have a way to trigger CI without a PR,
+    so this PR serves that purpose.
   COMMENT: "[citest]"
 jobs:
   weekly_ci:
@@ -16,7 +19,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
       - name: Create and push empty commit
         run: |
           set -euxo pipefail

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
 ---
+extends: default
 ignore: |
   /.tox/
-extends: default


### PR DESCRIPTION
There are now separate github actions for the various tests, instead of all of
them being done as part of the tox tests in tox.yml - ansible-lint,
ansible-test, etc.

Use the officially supported github actions e.g. for ansible-lint, ansible-test,
rather than using our own from `tox-lsr` and trying to keep up with the latest
changes.  Developers will still be able to use `tox-lsr` on their local
development environments to run these tests in the same way that they are run in
github actions, so that errors found when submitting PRs can be reproduced and
corrected locally without too many github UI roundtrips.

Using separate github actions, and especially the official github actions which
generally have support for in-line comments, should help greatly with
readability and troubleshooting test results.

Python tests are removed from roles that do not use python.

Python tests are now done by python-unit-tests.yml which also does the black,
flake8, and pylint tests.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
