### PR TITLE
Use templates instead of files for ansible_managed

### DIFF
--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -83,23 +83,32 @@
 - name: Set-up network flushing
   block:
     - name: Deploy network flushing script
-      copy:
-        src: "{{ role_path }}/files/nbde_client-network-flush"
+      template:
+        src: nbde_client-network-flush.j2
         dest: /usr/bin/nbde_client-network-flush
         mode: '0755'
 
     - name: Deploy network flushing service
-      copy:
-        src: "{{ role_path }}/files/nbde_client-network-flush.service"
+      template:
+        src: nbde_client-network-flush.service.j2
         dest: /etc/systemd/system/nbde_client-network-flush.service
         mode: '0644'
 
+    - name: Create a directory for nbde_client dracut network flushing module
+      file:
+        path: /usr/lib/dracut/modules.d/60nbde_client/
+        state: directory
+        mode: '0755'
+
     - name: Deploy nbde_client dracut network flushing module
-      copy:
-        src: "{{ role_path }}/files/nbde_client/"
-        dest: /usr/lib/dracut/modules.d/60nbde_client/
-        directory_mode: '0755'
+      template:
+        src: "{{ item }}"
+        dest: >-
+          /usr/lib/dracut/modules.d/60nbde_client/{{ item | splitext | first }}
         mode: '0644'
+      loop:
+        - module-setup.sh.j2
+        - nbde_client-hook.sh.j2
 
     - name: Prepare for network flushing - reset autoconnect-priority
       ansible.builtin.command:

--- a/templates/module-setup.sh.j2
+++ b/templates/module-setup.sh.j2
@@ -1,4 +1,6 @@
 #!/bin/sh
+{{ ansible_managed | comment }}
+{{ "system_role:nbde_client" | comment(prefix="", postfix="") }}
 
 depends() {
   echo network-manager

--- a/templates/nbde_client-hook.sh.j2
+++ b/templates/nbde_client-hook.sh.j2
@@ -1,4 +1,6 @@
 #!/bin/sh
+{{ ansible_managed | comment }}
+{{ "system_role:nbde_client" | comment(prefix="", postfix="") }}
 
 # disable_inird_connections() will disable autoconnect for the active
 # connections within the initramfs, so that these will not clash with

--- a/templates/nbde_client-network-flush.j2
+++ b/templates/nbde_client-network-flush.j2
@@ -1,4 +1,6 @@
 #!/bin/sh
+{{ ansible_managed | comment }}
+{{ "system_role:nbde_client" | comment(prefix="", postfix="") }}
 
 # do_flush() flushes every active network interface. It is intended to
 # run before NetworkManager starts, so that when it does it will be able

--- a/templates/nbde_client-network-flush.service.j2
+++ b/templates/nbde_client-network-flush.service.j2
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+{{ "system_role:nbde_client" | comment(prefix="", postfix="") }}
 [Unit]
 Description=Network flush service for nbde_client Ansible role
 Before=network-pre.target


### PR DESCRIPTION
Move files in the files directory to the templates; use the template module instead of copy for deploying them to add ansible_managed and fingerprint header.

Note: This fingerprint information is provided to help customers identify that it was generated by system roles. It may also be used for future analysis.