### PR TITLE
test: check generated files for ansible_managed, fingerprint

### DIFF
--- a/templates/nbde_client.conf
+++ b/templates/nbde_client.conf
@@ -1,4 +1,6 @@
 # nbde_client dracut config
+{{ ansible_managed | comment }}
+{{ "system_role:nbde_client" | comment(prefix="", postfix="") }}
 {% for line in __nbde_client_dracut_settings %}
 {{ line }}
 {% endfor %}

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Get file
+  slurp:
+    path: "{{ __file }}"
+  register: __content
+  when: not __file_content is defined
+
+- name: Check for presence of ansible managed header, fingerprint
+  assert:
+    that:
+      - ansible_managed in content
+      - __fingerprint in content
+  vars:
+    content: "{{ (__file_content | d(__content)).content | b64decode }}"
+    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/templates/get_ansible_managed.j2
+++ b/tests/templates/get_ansible_managed.j2
@@ -1,0 +1,1 @@
+{{ ansible_managed | comment(__comment_type | d("plain")) }}

--- a/tests/tests_simple_bind.yml
+++ b/tests/tests_simple_bind.yml
@@ -18,6 +18,19 @@
           include_role:
             name: linux-system-roles.nbde_client
 
+        - name: Check ansible_managed, fingerprint in generated files
+          include_tasks: tasks/check_header.yml
+          loop:
+            - /etc/dracut.conf.d/nbde_client.conf
+            - /usr/bin/nbde_client-network-flush
+            - /etc/systemd/system/nbde_client-network-flush.service
+            - /usr/lib/dracut/modules.d/60nbde_client/module-setup.sh
+            - /usr/lib/dracut/modules.d/60nbde_client/nbde_client-hook.sh
+          loop_control:
+            loop_var: __file
+          vars:
+            __fingerprint: "system_role:nbde_client"
+
         - name: Attempt to unlock device
           include_tasks: tasks/verify_unlock_device.yml
 


### PR DESCRIPTION
Add ansible_managed header and fingerprint to dracut config file

Add the following files: tests/tasks/check_header.yml and
tests/templates/get_ansible_managed.j2.
Use check_header.yml to check generated files for the ansible_managed
and fingerprint headers.
check_header.yml takes these parameters.  `fingerprint` is required,
and one of `__file` or `__file_content`:

* `__file` - the full path of the file to check e.g. `/etc/realmd.conf`
* `__file_content` - the output of `slurp` of the file
* `__fingerprint` - required - the fingerprint string `system_role:$ROLENAME` e.g.
  `__fingerprint: "system_role:postfix"`
* `__comment_type` - optional, default `plain` - the type of comments used

e.g. `__comment_type: c` for C/C++-style comments.  `plain` uses `#`.
See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#adding-comments-to-files
for the different types of comment styles supported.

Example:
```
- name: Check generated files for ansible_managed, fingerprint
  include_tasks: tasks/check_header.yml
  vars:
    __file: /etc/myfile.conf
    __fingerprint: "system_role:my_role"
```
