### PR TITLE
refactor: clear net config from initrd via NM config

### DIFF
--- a/tasks/clear_initrd_netcfg-dracut_module.yml
+++ b/tasks/clear_initrd_netcfg-dracut_module.yml
@@ -1,0 +1,45 @@
+---
+- name: Deploy network flushing script
+  template:
+    src: nbde_client-network-flush.j2
+    dest: /usr/bin/nbde_client-network-flush
+    mode: '0755'
+
+- name: Deploy network flushing service
+  template:
+    src: nbde_client-network-flush.service.j2
+    dest: /etc/systemd/system/nbde_client-network-flush.service
+    mode: '0644'
+
+- name: Create a directory for nbde_client dracut network flushing module
+  file:
+    path: /usr/lib/dracut/modules.d/60nbde_client/
+    state: directory
+    mode: '0755'
+
+- name: Deploy nbde_client dracut network flushing module
+  template:
+    src: "{{ item }}"
+    dest: >-
+      /usr/lib/dracut/modules.d/60nbde_client/{{ item | splitext | first }}
+    mode: '0644'
+  loop:
+    - module-setup.sh.j2
+    - nbde_client-hook.sh.j2
+
+- name: Prepare for network flushing - reset autoconnect-priority
+  ansible.builtin.command:
+    cmd: /usr/bin/nbde_client-network-flush reset-autoconn-prio
+  register: __nbde_client_autoconn_prio
+  changed_when: __nbde_client_autoconn_prio.stderr
+
+- name: Reload systemd config
+  systemd:
+    daemon_reload: true
+
+- name: Enable network flushing service
+  service:
+    name: nbde_client-network-flush.service
+    enabled: true
+
+# vim:set ts=2 sw=2 et:

--- a/tasks/clear_initrd_netcfg-networkmanager_config.yml
+++ b/tasks/clear_initrd_netcfg-networkmanager_config.yml
@@ -1,0 +1,8 @@
+---
+- name: Deploy NetworkManager configuration
+  template:
+    src: NetworkManager.conf.j2
+    dest: /etc/NetworkManager/conf.d/00-nbde_client.conf
+    mode: '0644'
+
+# vim:set ts=2 sw=2 et:

--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -80,49 +80,8 @@
         - nbde_client_bindings | default([])
         - nbde_client_tempdir.path is defined
 
-- name: Set-up network flushing
-  block:
-    - name: Deploy network flushing script
-      template:
-        src: nbde_client-network-flush.j2
-        dest: /usr/bin/nbde_client-network-flush
-        mode: '0755'
-
-    - name: Deploy network flushing service
-      template:
-        src: nbde_client-network-flush.service.j2
-        dest: /etc/systemd/system/nbde_client-network-flush.service
-        mode: '0644'
-
-    - name: Create a directory for nbde_client dracut network flushing module
-      file:
-        path: /usr/lib/dracut/modules.d/60nbde_client/
-        state: directory
-        mode: '0755'
-
-    - name: Deploy nbde_client dracut network flushing module
-      template:
-        src: "{{ item }}"
-        dest: >-
-          /usr/lib/dracut/modules.d/60nbde_client/{{ item | splitext | first }}
-        mode: '0644'
-      loop:
-        - module-setup.sh.j2
-        - nbde_client-hook.sh.j2
-
-    - name: Prepare for network flushing - reset autoconnect-priority
-      ansible.builtin.command:
-        cmd: /usr/bin/nbde_client-network-flush reset-autoconn-prio
-      register: __nbde_client_autoconn_prio
-      changed_when: __nbde_client_autoconn_prio.stderr
-
-    - name: Reload systemd config
-      systemd:
-        daemon_reload: true
-
-    - name: Enable network flushing service
-      service:
-        name: nbde_client-network-flush.service
-        enabled: true
+- name: Deploy mechanism to clear network configuration generated during early boot
+  include_tasks: clear_initrd_netcfg-{{ __nbde_client_clear_initrd_netcfg_strategy }}.yml
+  when: __nbde_client_clear_initrd_netcfg_strategy is defined
 
 # vim:set ts=2 sw=2 et:

--- a/templates/NetworkManager.conf.j2
+++ b/templates/NetworkManager.conf.j2
@@ -1,0 +1,6 @@
+# nbde_client NetworkManager config
+{{ ansible_managed | comment }}
+{{ "system_role:nbde_client" | comment(prefix="", postfix="") }}
+[device]
+keep-configuration=no
+allowed-connections=except:origin:nm-initrd-generator

--- a/vars/AlmaLinux_8.yml
+++ b/vars/AlmaLinux_8.yml
@@ -17,4 +17,6 @@ __nbde_client_dracut_settings:
   - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
+__nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
+
 # vim:set ts=2 sw=2 et:

--- a/vars/AlmaLinux_9.yml
+++ b/vars/AlmaLinux_9.yml
@@ -17,4 +17,6 @@ __nbde_client_dracut_settings:
   - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
+__nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
+
 # vim:set ts=2 sw=2 et:

--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -17,4 +17,6 @@ __nbde_client_dracut_settings:
   - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
+__nbde_client_clear_initrd_netcfg_strategy: dracut_module
+
 # vim:set ts=2 sw=2 et:

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -17,4 +17,6 @@ __nbde_client_dracut_settings:
   - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
+__nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
+
 # vim:set ts=2 sw=2 et:

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -17,4 +17,6 @@ __nbde_client_dracut_settings:
   - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
+__nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
+
 # vim:set ts=2 sw=2 et:

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -17,4 +17,6 @@ __nbde_client_dracut_settings:
   - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
+__nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
+
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -17,4 +17,6 @@ __nbde_client_dracut_settings:
   - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
+__nbde_client_clear_initrd_netcfg_strategy: dracut_module
+
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -17,4 +17,6 @@ __nbde_client_dracut_settings:
   - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
+__nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
+
 # vim:set ts=2 sw=2 et:

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -17,4 +17,6 @@ __nbde_client_dracut_settings:
   - kernel_cmdline+=" rd.neednet=1 "
   - omit_dracutmodules+=" ifcfg "
 
+__nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
+
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Uses a NetworkManager config drop in file to accomplish the equivalent of the previous network flushing dracut module.

I have no idea how correct my approach is, I took the general approach from another system role I found. Nor do I know of any way to properly test this on real systems.

Closes #155