### PR TITLE
fix: add support for EL10

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,9 +2,8 @@
 ---
 galaxy_info:
   author: Sergio Correia <scorreia@redhat.com>
-  description: >
-    Ansible role for configuring Network-Bound Disk Encryption clients
-    (e.g. clevis)
+  description: Ansible role for configuring Network-Bound Disk Encryption clients (e.g. clevis)
+
   company: Red Hat, Inc.
   license: MIT
   min_ansible_version: "2.9"
@@ -17,13 +16,15 @@ galaxy_info:
         - "7"
         - "8"
         - "9"
-
   galaxy_tags:
     - centos
-    - fedora
-    - redhat
-    - nbde
     - clevis
+    - el7
+    - el8
+    - el9
+    - el10
+    - fedora
+    - nbde
+    - redhat
     - tang
-
 dependencies: []

--- a/tests/vars/CentOS_10.yml
+++ b/tests/vars/CentOS_10.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+---
+# Put tests variables here with CentOS 9 specific values.
+
+nbde_client_test_packages:
+  - cryptsetup
+
+# vim:set ts=2 sw=2 et:

--- a/tests/vars/RedHat_10.yml
+++ b/tests/vars/RedHat_10.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+---
+# Put tests variables here with Red Hat Enterprise Linux 9 specific values.
+
+nbde_client_test_packages:
+  - cryptsetup
+
+# vim:set ts=2 sw=2 et:

--- a/vars/AlmaLinux_10.yml
+++ b/vars/AlmaLinux_10.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with AlmaLinux 10 specific values.
+
+__nbde_client_packages:
+  - clevis
+  - clevis-dracut
+  - clevis-luks
+  - clevis-systemd
+  - iproute
+  - NetworkManager
+
+__nbde_client_initramfs_update_cmd: >
+  dracut -fv --regenerate-all
+
+__nbde_client_dracut_settings:
+  - kernel_cmdline+=" rd.neednet=1 "
+  - omit_dracutmodules+=" ifcfg "
+
+__nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
+
+# vim:set ts=2 sw=2 et:

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with CentOS 10 specific values.
+
+__nbde_client_packages:
+  - clevis
+  - clevis-dracut
+  - clevis-luks
+  - clevis-systemd
+  - iproute
+  - NetworkManager
+
+__nbde_client_initramfs_update_cmd: >
+  dracut -fv --regenerate-all
+
+__nbde_client_dracut_settings:
+  - kernel_cmdline+=" rd.neednet=1 "
+  - omit_dracutmodules+=" ifcfg "
+
+__nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
+
+# vim:set ts=2 sw=2 et:

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 10 specific values.
+
+__nbde_client_packages:
+  - clevis
+  - clevis-dracut
+  - clevis-luks
+  - clevis-systemd
+  - iproute
+  - NetworkManager
+
+__nbde_client_initramfs_update_cmd: >
+  dracut -fv --regenerate-all
+
+__nbde_client_dracut_settings:
+  - kernel_cmdline+=" rd.neednet=1 "
+  - omit_dracutmodules+=" ifcfg "
+
+__nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
+
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

Many roles already have tags such as "rhel", "redhat", "centos", and "fedora".
I propose that we ensure all of the system roles have these tags.
Some of our roles support Suse, Debian, Ubuntu, and others.
We should add tags for those e.g. the ssh role already has tags for "debian" and "ubuntu".

In addition - for each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

In addition - for roles that have different variable files for EL9, create
the corresponding EL10 files.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
