### PR TITLE
chore: add debian late boot support

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,7 @@
+---
+__nbde_client_packages:
+  - clevis
+  - clevis-luks
+  - clevis-systemd
+
+nbde_client_early_boot: false


### PR DESCRIPTION
Enhancement: Adds support for Debian. However, since Debian only supports dm-crypt as a full-disk encryption method during install, support for early boot is explicitly disabled. This also prevents a dependency on NetworkManager, which is known to cause issues for some Debian-family distributions (notably Proxmox).

Reason: Needed Debian/Proxmox late-boot support

Result: Adds vars file for Debian, which will be included as OS family file.

Issue Tracker Tickets (Jira or BZ if any): N/A
