### PR TITLE
ci: use tox-lsr 3.6.0; improve qemu test logging

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -65,7 +65,7 @@ jobs:
             tox=tox
             virtualenv=virtualenv
           fi
-          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
+          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.6.0"
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported
@@ -109,14 +109,29 @@ jobs:
               echo "$f"
           done < batch.report
 
-      - name: Show test logs on failure
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: "logs-${{ matrix.scenario.image }}-${{ matrix.scenario.env }}"
+          path: |
+            tests/*.log
+            artifacts/default_provisioners.log
+            artifacts/*.qcow2.*.log
+            batch.txt
+            batch.report
+          retention-days: 30
+
+      - name: Show test log failures
         if: steps.check_platform.outputs.supported && failure()
         run: |
           set -euo pipefail
           for f in tests/*.log; do
-              echo "::group::$(basename $f)"
-              cat "$f"
-              echo "::endgroup::"
+              if FAIL=$(grep -B100 -A30 "fatal:" "$f"); then
+                  echo "::group::$(basename $f)"
+                  echo "$FAIL"
+                  echo "::endgroup::"
+              fi
           done
 
       - name: Set commit status as success with a description that platform is skipped


### PR DESCRIPTION
tox-lsr 3.6.0 will guarantee order of qemu test execution, which should
help make tests reproducible and help debug test failures.

Improve qemu test logging - this will help debug the qemu test
failures.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
