### PR TITLE
fix: Adjust for Ansible 2.19

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
 - name: Handle nbde_client update initramfs
   when:
     - __nbde_client_update_initramfs | bool
-    - __nbde_client_initramfs_update_cmd | default("")
+    - __nbde_client_initramfs_update_cmd | default("") | length > 0
   command: "{{ __nbde_client_initramfs_update_cmd }}"
   changed_when: false
 

--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -24,7 +24,7 @@
 
 - name: Check whether devices are at the desired state
   when:
-    - nbde_client_bindings | default([])
+    - nbde_client_bindings | default([]) | length > 0
   nbde_client_clevis:
     bindings: "{{ nbde_client_bindings | default([]) }}"
   check_mode: true
@@ -41,7 +41,7 @@
         state: directory
         suffix: nbde_client_encryption_keys
       when:
-        - nbde_client_bindings | default([])
+        - nbde_client_bindings | default([]) | length > 0
       register: nbde_client_tempdir
 
     - name: Ensure we transfer key files
@@ -51,7 +51,7 @@
         mode: '0400'
       when:
         - nbde_client_tempdir.path is defined
-        - item.encryption_key_src | default("")
+        - item.encryption_key_src | default("") | length > 0
       loop: "{{ nbde_client_bindings }}"
       loop_control:
         label: "{{ item.encryption_key_src | default('') }}"
@@ -59,7 +59,7 @@
 
     - name: Perform clevis operations
       when:
-        - nbde_client_bindings | default([])
+        - nbde_client_bindings | default([]) | length > 0
         - nbde_client_tempdir.path is defined
       nbde_client_clevis:
         bindings: "{{ nbde_client_bindings | default([]) }}"
@@ -78,7 +78,7 @@
         path: "{{ nbde_client_tempdir.path }}"
         state: absent
       when:
-        - nbde_client_bindings | default([])
+        - nbde_client_bindings | default([]) | length > 0
         - nbde_client_tempdir.path is defined
 
 - name: Deploy mechanism to clear network configuration generated during early boot

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/tests_default_vars.yml
+++ b/tests/tests_default_vars.yml
@@ -9,8 +9,8 @@
             name: linux-system-roles.nbde_client
         - name: Assert that the role declares all parameters in defaults
           assert:
-            that: "{{ item }} is defined"
-          loop:
-            - nbde_client_provider
-            - nbde_client_bindings
+            that:
+              - nbde_client_provider is defined
+              - nbde_client_bindings is defined
+
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
- Ensure boolean values for `when:` conditions.
- Avoid `ansible_managed` variable, it's an internal constant.
- Remove jinja templates from assertions.

---

Introduced in #205 [log](https://github.com/linux-system-roles/nbde_client/actions/runs/15545982728/job/43767410206), also see #140

## Summary by Sourcery

Adjust role for compatibility with Ansible 2.19 by enforcing boolean conditions, avoiding internal variables, and simplifying tests

Bug Fixes:
- Ensure `when` conditions return booleans by adding `| length > 0` to list and string checks
- Replace use of `ansible_managed` with `__ansible_managed` to avoid internal collisions

Tests:
- Refactor default vars assertion to a single list of definitions
- Simplify header check test to use `__ansible_managed` and remove Jinja loops