### PR TITLE
feat: new variable `nbde_client_secure_logging` defaulting to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These are the variables that can be passed to the role:
 | `nbde_client_provider` | `clevis`| identifies the provider for the `nbde_client` role. We currently support `clevis`.|
 | `nbde_client_bindings` | | a list containing binding configurations, which include e.g. devices and slots. |
 | `nbde_client_early_boot` | `true` | by default nbde_client will configure the initrd to unlock the volume. This may need to be disabled if the managed host is using static IP addressing, or if the volume should be unlocked by clevis-luks-askpass |
+| `nbde_client_secure_logging` | `true` | If true, suppress potentially sensitive output from tasks that handle credentials, secrets, and other sensitive data. Set to false for debugging issues with credential handling or secret management, but be aware this may expose sensitive information in logs. |
 
 ### nbde_client_bindings
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,5 +21,6 @@ nbde_client_early_boot: true
 #        - http://server1.example.com
 #        - http://server2.example.com
 nbde_client_bindings: []
+nbde_client_secure_logging: true
 
 # vim:set ts=2 sw=2 et:

--- a/tasks/main-clevis.yml
+++ b/tasks/main-clevis.yml
@@ -6,6 +6,7 @@
 
 - name: Get services
   service_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Enable clevis askpass unit
   systemd:
@@ -29,7 +30,7 @@
     bindings: "{{ nbde_client_bindings | default([]) }}"
   check_mode: true
   register: __nbde_client_clevis_check_state
-  no_log: true
+  no_log: "{{ nbde_client_secure_logging }}"
 
 - name: Prepare key files, perform clevis operations and dispose of key files
   when:
@@ -55,7 +56,7 @@
       loop: "{{ nbde_client_bindings }}"
       loop_control:
         label: "{{ item.encryption_key_src | default('') }}"
-      no_log: true
+      no_log: "{{ nbde_client_secure_logging }}"
 
     - name: Perform clevis operations
       when:
@@ -65,7 +66,7 @@
         bindings: "{{ nbde_client_bindings | default([]) }}"
         data_dir: "{{ nbde_client_tempdir.path }}"
       notify: Handle nbde_client update initramfs
-      no_log: true
+      no_log: "{{ nbde_client_secure_logging }}"
 
   rescue:
     - name: Failed message


### PR DESCRIPTION
Feature: Introduce the `nbde_client_secure_logging` variable that defaults to `true` and using verbosity-based logging for facts modules.

Reason: Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult. Users cannot see credential-related output even when troubleshooting authentication or secret management issues. Additionally, service_facts produces verbose output that clutters logs during normal operation.

Result:
  - Tasks handling credentials, secrets, and sensitive data now use no_log: "{{ nbde_client_secure_logging }}", allowing users to set nbde_client_secure_logging: false for debugging while maintaining secure defaults (true)
  - service_facts now uses no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - New variable nbde_client_secure_logging documented in README.md with guidance on when to disable it
  - Users can now debug credential and secret issues without modifying role code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce configurable secure logging for NBDE client tasks and adjust service facts logging based on Ansible verbosity.

New Features:
- Add nbde_client_secure_logging variable to control suppression of sensitive task output, defaulting to secure behavior.

Enhancements:
- Switch sensitive clevis-related tasks from hard-coded no_log to using the nbde_client_secure_logging setting.
- Make service_facts logging conditional on Ansible verbosity to reduce noisy output at normal log levels.

Documentation:
- Document the nbde_client_secure_logging variable and its recommended usage in the README.