### PR TITLE
docs(changelog): version 1.5.0 [citest_skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -201,6 +201,14 @@ volume. This may need to be disabled if the managed host is using static
 IP addressing, or if the volume should be unlocked by
 clevis-luks-askpass</td>
 </tr>
+<tr>
+<td><code>nbde_client_secure_logging</code></td>
+<td><code>true</code></td>
+<td>If true, suppress potentially sensitive output from tasks that
+handle credentials, secrets, and other sensitive data. Set to false for
+debugging issues with credential handling or secret management, but be
+aware this may expose sensitive information in logs.</td>
+</tr>
 </tbody>
 </table>
 <h2 id="nbde_client_bindings">nbde_client_bindings</h2>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+[1.5.0] - 2026-05-07
+--------------------
+
+### New Features
+
+- feat: new variable `nbde_client_secure_logging` defaulting to `true` (#257)
+
+### Other Changes
+
+- ci: bump actions/github-script from 8 to 9 (#256)
+
 [1.4.0] - 2026-04-28
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.5.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update release metadata for version 1.5.0.

New Features:
- Document the new nbde_client_secure_logging variable and its default behavior.

Documentation:
- Add changelog entry for version 1.5.0 highlighting new configuration and CI change.
- Update README HTML to describe the nbde_client_secure_logging option and its purpose.