### PR TITLE
test: test reboot and unlock with separate nbde_server machine

### DIFF
--- a/tests/provision.fmf
+++ b/tests/provision.fmf
@@ -1,3 +1,5 @@
 standard-inventory-qcow2:
   qemu:
     m: 2048
+    drive:
+      - size: 10737418240

--- a/tests/tasks/setup_test.yml
+++ b/tests/tasks/setup_test.yml
@@ -55,6 +55,7 @@
 - name: Deploy NBDE server for testing
   include_role:
     name: fedora.linux_system_roles.nbde_server
+  when: hostvars.keys() | list | length == 1
 
 - name: Create device for testing
   command: fallocate -l64m {{ nbde_client_test_device }}
@@ -88,4 +89,46 @@
   delegate_to: localhost
   changed_when: false
 
+- name: Setup for separate NBDE server host
+  when: hostvars.keys() | list | length > 1
+  block:
+    - name: Get unused disk for testing
+      fedora.linux_system_roles.find_unused_disk:
+        max_return: 1
+      register: __register_unused_disk
+
+    - name: Set nbde_client test variables - 1
+      set_fact:
+        nbde_client_test_device: "/dev/{{ __register_unused_disk.disks[0] }}"
+        nbde_client_test_mount_location: "/mnt/nbde_client_test"
+        nbde_client_test_encryption_password: nbde_client_test_passphrase
+        nbde_client_test_encryption_luks_version: luks2
+        nbde_client_test_file_contents: This is a test file for nbde_client tests
+
+    - name: Set nbde_client test variables - 2
+      set_fact:
+        nbde_client_test_file: "{{ nbde_client_test_mount_location }}/test.txt"
+
+    - name: Encrypt test disk
+      include_role:
+        name: fedora.linux_system_roles.storage
+      vars:
+        storage_volumes:
+          - name: nbde_client_volume
+            type: disk
+            disks: "{{ __register_unused_disk.disks }}"
+            mount_point: "{{ nbde_client_test_mount_location }}"
+            encryption: true
+            encryption_password: "{{ nbde_client_test_encryption_password }}"
+            encryption_luks_version: "{{ nbde_client_test_encryption_luks_version }}"
+
+    - name: Create test file
+      copy:
+        content: "{{ nbde_client_test_file_contents }}"
+        dest: "{{ nbde_client_test_file }}"
+        mode: "0644"
+
+    - name: Check that volume is setup for luks
+      command: cryptsetup luksDump {{ nbde_client_test_device }}
+      changed_when: false
 # vim:set ts=2 sw=2 et:

--- a/tests/tests_simple_bind_multihost.yml
+++ b/tests/tests_simple_bind_multihost.yml
@@ -1,0 +1,86 @@
+---
+- name: Setup nbde_server
+  hosts: nbde-server
+  tasks:
+    - name: Deploy NBDE server for testing
+      include_role:
+        name: fedora.linux_system_roles.nbde_server
+
+- name: Test simple bind
+  hosts: nbde-client
+  vars:
+    nbde_client_bindings:
+      - device: "{{ nbde_client_test_device }}"
+        encryption_password: "{{ nbde_client_test_encryption_password }}"
+        servers:
+          - http://nbde-server
+
+  tasks:
+    - name: Set up test environment
+      include_tasks: tasks/setup_test.yml
+
+    - name: Run the test
+      block:
+        - name: Use nbde_client role
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
+
+        - name: Flush handlers
+          meta: flush_handlers
+
+        - name: Reboot the client
+          reboot:
+
+        - name: Verify that the test file is present with the unencrypted contents
+          copy:
+            content: "{{ nbde_client_test_file_contents }}"
+            dest: "{{ nbde_client_test_file }}"
+            mode: "0644"
+          register: __register_copy_test_file
+          failed_when: __register_copy_test_file is failed or __register_copy_test_file is changed
+      rescue:
+        - name: Check various states of the system
+          shell:
+            executable: /bin/bash
+            cmd: |
+              set -uxo pipefail
+              exec 1>&2
+              df -H
+              mount
+              cat /etc/fstab
+              cat /etc/crypttab
+              ls -alrtF /mnt/nbde_client_test
+              dmesg | grep -E -i 'luks|clevis'
+              journalctl -ex | grep -E -i 'luks|clevis'
+              journalctl -ex -u clevis-luks-askpass.service
+              lsblk
+              blkid
+              lsinitrd | grep -i clevis
+              clevis luks list -d {{ nbde_client_test_device }}
+              systemctl --version
+              firewall-cmd --list-all-zones
+              grep type=AVC /var/log/audit/audit.log
+              exit 0
+          changed_when: false
+
+        - name: Check the nbde_server machine
+          delegate_to: nbde-server
+          shell:
+            executable: /bin/bash
+            cmd: |
+              set -uxo pipefail
+              exec 1>&2
+              journalctl -ex
+              ss -nltp
+              firewall-cmd --list-all-zones
+              grep type=AVC /var/log/audit/audit.log
+          changed_when: false
+
+        - name: Fail
+          fail:
+
+      always:
+        - name: Clean up test environment
+          include_tasks: tasks/cleanup_test.yml
+# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
This relies on https://github.com/linux-system-roles/tox-lsr/pull/244
or some other system by which you can create two machines with hostnames
nbde-server and nbde-client that can network with each other.

Run it like this:

```bash
tox -e libvirt-ansible-core-2-X -- --image-name centos-Y --log-level debug --hostnames nbde-client --hostnames nbde-server -- \
  tests/tests_simple_bind_multihost.yml 2>&1 | tee output
```

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new multi-host test playbook covering client/server binding workflows, including reboot, file transfer checks, diagnostics on failure, and guaranteed cleanup.
  * Improved test setup logic to handle single-host vs multi-host runs, provisioning an encrypted disk-backed volume and validating it is configured as LUKS in multi-host scenarios.
  * Increased the configured QCOW2 virtual disk size for the `standard-inventory-qcow2` target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->