### PR TITLE
fix: use hostonly_cmdline=yes on newer versions of OS

### DIFF
--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -15,8 +15,7 @@ __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all
 
 __nbde_client_dracut_settings:
-  - kernel_cmdline+=" rd.neednet=1 "
-  - omit_dracutmodules+=" ifcfg "
+  - hostonly_cmdline=yes
 
 __nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
 

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -15,8 +15,7 @@ __nbde_client_initramfs_update_cmd: >
   dracut -fv --regenerate-all
 
 __nbde_client_dracut_settings:
-  - kernel_cmdline+=" rd.neednet=1 "
-  - omit_dracutmodules+=" ifcfg "
+  - hostonly_cmdline=yes
 
 __nbde_client_clear_initrd_netcfg_strategy: networkmanager_config
 


### PR DESCRIPTION
Newer versions of the OS will configure dracut networking correctly with
the use of `hostonly_cmdline=yes` and this is what is recommended by
the NBDE documentation.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network boot configuration on Fedora and Red Hat 10 systems by using host-only kernel command-line settings.
  * Removed previous networking-specific boot options that could cause inconsistent initialization during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->