### PR TITLE
feat: Argument spec implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ This role can currently create `tang` bindings. TPM2 is not supported as of now.
 
 ## Role Variables
 
-These are the variables that can be passed to the role:
+These are the variables that can be passed to the role.
+
+Type, required-field, and choice validation is enforced by
+`meta/argument_specs.yml`. Role tasks enforce cross-field validation.
 
 | **Variable** | **Default/Choices** | **Description** |
 |----------|-------------|------|

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This role can currently create `tang` bindings. TPM2 is not supported as of now.
 These are the variables that can be passed to the role.
 
 Type, required-field, and choice validation is enforced by
-`meta/argument_specs.yml`. Role tasks enforce cross-field validation.
+`meta/argument_specs.yml` and `tasks/assert_role_vars.yml`.
 
 | **Variable** | **Default/Choices** | **Description** |
 |----------|-------------|------|

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -11,23 +11,26 @@ argument_specs:
     options:
       nbde_client_provider:
         type: str
+        default: clevis
         choices:
           - clevis
         description: >
           The provider for the nbde_client role. Currently only `clevis`
-          is supported. Defaults to `clevis`.
+          is supported.
       nbde_client_early_boot:
         type: bool
+        default: true
         description: >
           Whether to configure the initrd to unlock the volume during
           early boot. When `false`, the volume is unlocked by
-          clevis-luks-askpass instead. Defaults to `true`.
+          clevis-luks-askpass instead.
       nbde_client_bindings:
         type: list
         elements: dict
+        default: []
         description: >
           A list of binding configurations specifying devices, servers,
-          and related parameters for NBDE setup. Defaults to `[]`.
+          and related parameters for NBDE setup.
         options:
           device:
             type: path
@@ -48,16 +51,18 @@ argument_specs:
               encryption key valid for opening the specified device.
           state:
             type: str
+            default: present
             choices:
               - present
               - absent
             description: >
               Whether a binding should be added (`present`) or removed
-              (`absent`). Defaults to `present`.
+              (`absent`).
           slot:
             type: int
+            default: 1
             description: >
-              The LUKS slot to use for the binding. Defaults to `1`.
+              The LUKS slot to use for the binding.
           servers:
             type: list
             elements: str
@@ -66,26 +71,29 @@ argument_specs:
               than one server enables high availability.
           threshold:
             type: int
+            default: 1
             description: >
               The threshold for the Shamir Secret Sharing scheme when
               using multiple servers. Indicates how many servers must
-              succeed for decryption. Defaults to `1`.
+              succeed for decryption.
           password_temporary:
             type: bool
+            default: false
             description: >
               If `true`, the encryption password or key will be removed
               from the LUKS device after the binding operation completes.
-              Defaults to `false`.
       nbde_client_secure_logging:
         type: bool
+        default: true
         description: >
           If `true`, suppresses potentially sensitive output from tasks
-          that handle credentials and secrets. Defaults to `true`.
+          that handle credentials and secrets.
       nbde_client_extra_dracut_settings:
         type: list
         elements: str
+        default: []
         description: >
           A list of extra dracut configuration lines written to
           `/etc/dracut.conf.d/nbde_client.conf`. Useful for static IP
           early-boot networking. Requires `nbde_client_early_boot` to be
-          `true`. Defaults to `[]`.
+          `true`.

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: MIT
+---
+argument_specs:
+  main:
+    short_description: The nbde_client role.
+    description: >
+      The nbde_client role allows you to configure Network-Bound Disk
+      Encryption (NBDE) clients. It manages LUKS device bindings to tang
+      servers and optionally configures early boot (dracut) to unlock
+      encrypted volumes during the initramfs stage.
+    options:
+      nbde_client_provider:
+        type: str
+        choices:
+          - clevis
+        description: >
+          The provider for the nbde_client role. Currently only `clevis`
+          is supported. Defaults to `clevis`.
+      nbde_client_early_boot:
+        type: bool
+        description: >
+          Whether to configure the initrd to unlock the volume during
+          early boot. When `false`, the volume is unlocked by
+          clevis-luks-askpass instead. Defaults to `true`.
+      nbde_client_bindings:
+        type: list
+        elements: dict
+        description: >
+          A list of binding configurations specifying devices, servers,
+          and related parameters for NBDE setup. Defaults to `[]`.
+        options:
+          device:
+            type: path
+            required: true
+            description: >
+              The path of the backing device of an encrypted LUKS device
+              on the managed host. The device must already be configured
+              as a LUKS device.
+          encryption_password:
+            type: str
+            description: >
+              A valid password or passphrase for opening the specified
+              device. It is recommended to vault-encrypt the value.
+          encryption_key_src:
+            type: path
+            description: >
+              The path on the control node of a file containing an
+              encryption key valid for opening the specified device.
+          state:
+            type: str
+            choices:
+              - present
+              - absent
+            description: >
+              Whether a binding should be added (`present`) or removed
+              (`absent`). Defaults to `present`.
+          slot:
+            type: int
+            description: >
+              The LUKS slot to use for the binding. Defaults to `1`.
+          servers:
+            type: list
+            elements: str
+            description: >
+              A list of tang server URLs to bind to. Specifying more
+              than one server enables high availability.
+          threshold:
+            type: int
+            description: >
+              The threshold for the Shamir Secret Sharing scheme when
+              using multiple servers. Indicates how many servers must
+              succeed for decryption. Defaults to `1`.
+          password_temporary:
+            type: bool
+            description: >
+              If `true`, the encryption password or key will be removed
+              from the LUKS device after the binding operation completes.
+              Defaults to `false`.
+      nbde_client_secure_logging:
+        type: bool
+        description: >
+          If `true`, suppresses potentially sensitive output from tasks
+          that handle credentials and secrets. Defaults to `true`.
+      nbde_client_extra_dracut_settings:
+        type: list
+        elements: str
+        description: >
+          A list of extra dracut configuration lines written to
+          `/etc/dracut.conf.d/nbde_client.conf`. Useful for static IP
+          early-boot networking. Requires `nbde_client_early_boot` to be
+          `true`. Defaults to `[]`.

--- a/tasks/assert_role_vars.yml
+++ b/tasks/assert_role_vars.yml
@@ -3,10 +3,12 @@
 - name: Assert slot is a positive integer
   ansible.builtin.assert:
     that:
+      - item.slot is not sameas true
+      - item.slot is not sameas false
       - item.slot | int >= 1
     fail_msg: >-
       nbde_client_bindings[{{ idx }}].slot must be a positive integer,
-      got {{ item.slot }}
+      got {{ item.slot }} ({{ item.slot | type_debug }})
   loop: "{{ nbde_client_bindings }}"
   loop_control:
     index_var: idx
@@ -16,10 +18,12 @@
 - name: Assert threshold is a positive integer
   ansible.builtin.assert:
     that:
+      - item.threshold is not sameas true
+      - item.threshold is not sameas false
       - item.threshold | int >= 1
     fail_msg: >-
       nbde_client_bindings[{{ idx }}].threshold must be a positive
-      integer, got {{ item.threshold }}
+      integer, got {{ item.threshold }} ({{ item.threshold | type_debug }})
   loop: "{{ nbde_client_bindings }}"
   loop_control:
     index_var: idx

--- a/tasks/assert_role_vars.yml
+++ b/tasks/assert_role_vars.yml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Assert slot is a positive integer
+  ansible.builtin.assert:
+    that:
+      - item.slot | int >= 1
+    fail_msg: >-
+      nbde_client_bindings[{{ idx }}].slot must be a positive integer,
+      got {{ item.slot }}
+  loop: "{{ nbde_client_bindings }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item.device | d('unnamed') }}"
+  when: item.slot is defined
+
+- name: Assert threshold is a positive integer
+  ansible.builtin.assert:
+    that:
+      - item.threshold | int >= 1
+    fail_msg: >-
+      nbde_client_bindings[{{ idx }}].threshold must be a positive
+      integer, got {{ item.threshold }}
+  loop: "{{ nbde_client_bindings }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item.device | d('unnamed') }}"
+  when: item.threshold is defined
+
+- name: Assert servers is set when state is present
+  ansible.builtin.assert:
+    that:
+      - item.servers | default([]) | length > 0
+    fail_msg: >-
+      nbde_client_bindings[{{ idx }}].servers is required when state is
+      present
+  loop: "{{ nbde_client_bindings }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item.device | d('unnamed') }}"
+  when: (item.state | default('present')) == 'present'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,10 @@
     - not nbde_client_early_boot
     - nbde_client_extra_dracut_settings | length > 0
 
+- name: Validate role parameters
+  ansible.builtin.include_tasks: assert_role_vars.yml
+  when: nbde_client_bindings | length > 0
+
 # Set up internal variables.
 - name: Set version specific variables
   include_tasks: set_vars.yml

--- a/tests/tests_invalid_input.yml
+++ b/tests/tests_invalid_input.yml
@@ -223,8 +223,92 @@
                   nbde_client_extra_dracut_settings with type string
 
         # ====================================================
-        # Section 3: Cross-field validation (all versions)
+        # Section 3: assert_role_vars validation (all versions)
         # ====================================================
+
+        # --- Test: slot with invalid range ---
+        - name: Assert rejects slot less than 1
+          block:
+            - name: Run role with slot 0
+              ansible.builtin.include_role:
+                name: linux-system-roles.nbde_client
+              vars:
+                nbde_client_bindings:
+                  - device: /dev/sda1
+                    slot: 0
+                    servers:
+                      - http://server1.example.com
+          rescue:
+            - name: Mark invalid slot range rejected
+              ansible.builtin.set_fact:
+                __invalid_input_slot_range_failed: true
+              when: >-
+                'must be a positive integer' in
+                (ansible_failed_result | default({}) | to_json)
+
+        - name: Assert invalid slot range was rejected
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_slot_range_failed | default(false)
+            fail_msg: >-
+              assert_role_vars should reject slot values less than 1
+
+        # --- Test: threshold with invalid range ---
+        - name: Assert rejects threshold less than 1
+          block:
+            - name: Run role with threshold 0
+              ansible.builtin.include_role:
+                name: linux-system-roles.nbde_client
+              vars:
+                nbde_client_bindings:
+                  - device: /dev/sda1
+                    threshold: 0
+                    servers:
+                      - http://server1.example.com
+          rescue:
+            - name: Mark invalid threshold range rejected
+              ansible.builtin.set_fact:
+                __invalid_input_threshold_range_failed: true
+              when: >-
+                'must be a positive integer' in
+                (ansible_failed_result | default({}) | to_json)
+
+        - name: Assert invalid threshold range was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_threshold_range_failed
+                | default(false)
+            fail_msg: >-
+              assert_role_vars should reject threshold values less than 1
+
+        # --- Test: missing servers when state is present ---
+        - name: Assert rejects missing servers when state is present
+          block:
+            - name: Run role with state present and no servers
+              ansible.builtin.include_role:
+                name: linux-system-roles.nbde_client
+              vars:
+                nbde_client_bindings:
+                  - device: /dev/sda1
+                    state: present
+          rescue:
+            - name: Mark missing servers rejected
+              ansible.builtin.set_fact:
+                __invalid_input_missing_servers_failed: true
+              when: >-
+                'servers is required' in
+                (ansible_failed_result | default({}) | to_json)
+
+        - name: Assert missing servers was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_missing_servers_failed
+                | default(false)
+            fail_msg: >-
+              assert_role_vars should reject bindings with state present
+              and no servers
 
         # --- Test: extra_dracut_settings with early_boot disabled ---
         - name: Role rejects extra_dracut_settings when early_boot is false
@@ -266,5 +350,8 @@
             __invalid_input_password_temporary_type_failed:
             __invalid_input_secure_logging_type_failed:
             __invalid_input_extra_dracut_type_failed:
+            __invalid_input_slot_range_failed:
+            __invalid_input_threshold_range_failed:
+            __invalid_input_missing_servers_failed:
             __invalid_input_extra_dracut_early_boot_failed:
           tags: tests::cleanup

--- a/tests/tests_invalid_input.yml
+++ b/tests/tests_invalid_input.yml
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Verify invalid parameters are rejected
+  hosts: all
+  tasks:
+    - name: Run invalid input tests
+      block:
+        # ====================================================
+        # Section 1: Verify role works with valid defaults
+        # ====================================================
+        - name: Run role with valid defaults
+          ansible.builtin.include_role:
+            name: linux-system-roles.nbde_client
+
+        # ====================================================
+        # Section 2: argument_specs validation (Ansible 2.10+)
+        # ====================================================
+        - name: Run argument specs validation tests
+          when: ansible_version.full is version("2.10", ">=")
+          block:
+            # --- Test: invalid provider choice ---
+            - name: Argument specs reject invalid nbde_client_provider
+              block:
+                - name: Run role with invalid provider
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.nbde_client
+                  vars:
+                    nbde_client_provider: invalid_provider
+              rescue:
+                - name: Mark invalid provider rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_provider_choice_failed: true
+
+            - name: Assert invalid provider was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_provider_choice_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject nbde_client_provider value
+                  'invalid_provider'
+
+            # --- Test: invalid type for early_boot ---
+            - name: Argument specs reject non-bool nbde_client_early_boot
+              block:
+                - name: Run role with non-bool early_boot
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.nbde_client
+                  vars:
+                    nbde_client_early_boot: not_a_bool
+              rescue:
+                - name: Mark invalid early_boot type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_early_boot_type_failed: true
+
+            - name: Assert invalid early_boot type was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_early_boot_type_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject nbde_client_early_boot with
+                  type string
+
+            # --- Test: invalid type for bindings ---
+            - name: Argument specs reject non-list nbde_client_bindings
+              block:
+                - name: Run role with non-list bindings
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.nbde_client
+                  vars:
+                    nbde_client_bindings: not_a_list
+              rescue:
+                - name: Mark invalid bindings type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_bindings_type_failed: true
+
+            - name: Assert invalid bindings type was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_bindings_type_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject nbde_client_bindings with
+                  type string
+
+            # --- Test: missing required device in bindings ---
+            - name: Argument specs reject missing device in bindings
+              block:
+                - name: Run role without required device
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.nbde_client
+                  vars:
+                    nbde_client_bindings:
+                      - state: present
+              rescue:
+                - name: Mark missing device rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_missing_device_failed: true
+                  when: >-
+                    'missing required arguments' in
+                    (ansible_failed_result | default({}) | to_json)
+
+            - name: Assert missing device was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_missing_device_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject nbde_client_bindings entries
+                  missing the required device field
+
+            # --- Test: invalid choice for state in bindings ---
+            - name: Argument specs reject invalid state in bindings
+              block:
+                - name: Run role with invalid state
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.nbde_client
+                  vars:
+                    nbde_client_bindings:
+                      - device: /dev/sda1
+                        state: invalid_state
+              rescue:
+                - name: Mark invalid state choice rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_state_choice_failed: true
+
+            - name: Assert invalid state choice was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_state_choice_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject state value
+                  'invalid_state'
+
+            # --- Test: invalid type for slot in bindings ---
+            - name: Argument specs reject non-int slot in bindings
+              block:
+                - name: Run role with non-int slot
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.nbde_client
+                  vars:
+                    nbde_client_bindings:
+                      - device: /dev/sda1
+                        slot: not_an_int
+              rescue:
+                - name: Mark invalid slot type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_slot_type_failed: true
+
+            - name: Assert invalid slot type was rejected
+              ansible.builtin.assert:
+                that:
+                  - __invalid_input_slot_type_failed | default(false)
+                fail_msg: >-
+                  argument_specs should reject slot with type string
+
+            # --- Test: invalid type for password_temporary in bindings ---
+            - name: Argument specs reject non-bool password_temporary
+              block:
+                - name: Run role with non-bool password_temporary
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.nbde_client
+                  vars:
+                    nbde_client_bindings:
+                      - device: /dev/sda1
+                        password_temporary: not_a_bool
+              rescue:
+                - name: Mark invalid password_temporary type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_password_temporary_type_failed: true
+
+            - name: Assert invalid password_temporary type was rejected
+              ansible.builtin.assert:
+                that:
+                  - >-
+                    __invalid_input_password_temporary_type_failed
+                    | default(false)
+                fail_msg: >-
+                  argument_specs should reject password_temporary with
+                  type string
+
+            # --- Test: invalid type for secure_logging ---
+            - name: Argument specs reject non-bool nbde_client_secure_logging
+              block:
+                - name: Run role with non-bool secure_logging
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.nbde_client
+                  vars:
+                    nbde_client_secure_logging: not_a_bool
+              rescue:
+                - name: Mark invalid secure_logging type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_secure_logging_type_failed: true
+
+            - name: Assert invalid secure_logging type was rejected
+              ansible.builtin.assert:
+                that:
+                  - >-
+                    __invalid_input_secure_logging_type_failed
+                    | default(false)
+                fail_msg: >-
+                  argument_specs should reject nbde_client_secure_logging
+                  with type string
+
+            # --- Test: invalid type for extra_dracut_settings ---
+            - name: Argument specs reject non-list extra_dracut_settings
+              block:
+                - name: Run role with non-list extra_dracut_settings
+                  ansible.builtin.include_role:
+                    name: linux-system-roles.nbde_client
+                  vars:
+                    nbde_client_extra_dracut_settings: not_a_list
+              rescue:
+                - name: Mark invalid extra_dracut_settings type rejected
+                  ansible.builtin.set_fact:
+                    __invalid_input_extra_dracut_type_failed: true
+
+            - name: Assert invalid extra_dracut_settings type was rejected
+              ansible.builtin.assert:
+                that:
+                  - >-
+                    __invalid_input_extra_dracut_type_failed
+                    | default(false)
+                fail_msg: >-
+                  argument_specs should reject
+                  nbde_client_extra_dracut_settings with type string
+
+        # ====================================================
+        # Section 3: Cross-field validation (all versions)
+        # ====================================================
+
+        # --- Test: extra_dracut_settings with early_boot disabled ---
+        - name: Role rejects extra_dracut_settings when early_boot is false
+          block:
+            - name: Run role with extra_dracut_settings and early_boot false
+              ansible.builtin.include_role:
+                name: linux-system-roles.nbde_client
+              vars:
+                nbde_client_early_boot: false
+                nbde_client_extra_dracut_settings:
+                  - kernel_cmdline+=" ip=dhcp "
+          rescue:
+            - name: Mark extra_dracut with early_boot false rejected
+              ansible.builtin.set_fact:
+                __invalid_input_extra_dracut_early_boot_failed: true
+              when: >-
+                'nbde_client_extra_dracut_settings requires' in
+                (ansible_failed_result | default({}) | to_json)
+
+        - name: Assert extra_dracut with early_boot false was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_extra_dracut_early_boot_failed
+                | default(false)
+            fail_msg: >-
+              Role should reject nbde_client_extra_dracut_settings when
+              nbde_client_early_boot is false
+
+      always:
+        - name: Clear test facts
+          ansible.builtin.set_fact:
+            __invalid_input_provider_choice_failed:
+            __invalid_input_early_boot_type_failed:
+            __invalid_input_bindings_type_failed:
+            __invalid_input_missing_device_failed:
+            __invalid_input_state_choice_failed:
+            __invalid_input_slot_type_failed:
+            __invalid_input_password_temporary_type_failed:
+            __invalid_input_secure_logging_type_failed:
+            __invalid_input_extra_dracut_type_failed:
+            __invalid_input_extra_dracut_early_boot_failed:
+          tags: tests::cleanup

--- a/tests/tests_invalid_input.yml
+++ b/tests/tests_invalid_input.yml
@@ -13,10 +13,10 @@
             name: linux-system-roles.nbde_client
 
         # ====================================================
-        # Section 2: argument_specs validation (Ansible 2.10+)
+        # Section 2: argument_specs validation (Ansible 2.11+)
         # ====================================================
         - name: Run argument specs validation tests
-          when: ansible_version.full is version("2.10", ">=")
+          when: ansible_version.full is version("2.11", ">=")
           block:
             # --- Test: invalid provider choice ---
             - name: Argument specs reject invalid nbde_client_provider
@@ -253,6 +253,33 @@
             fail_msg: >-
               assert_role_vars should reject slot values less than 1
 
+        # --- Test: slot as boolean ---
+        - name: Assert rejects boolean slot
+          block:
+            - name: Run role with boolean slot
+              ansible.builtin.include_role:
+                name: linux-system-roles.nbde_client
+              vars:
+                nbde_client_bindings:
+                  - device: /dev/sda1
+                    slot: true
+                    servers:
+                      - http://server1.example.com
+          rescue:
+            - name: Mark boolean slot rejected
+              ansible.builtin.set_fact:
+                __invalid_input_slot_bool_failed: true
+              when: >-
+                'must be a positive integer' in
+                (ansible_failed_result | default({}) | to_json)
+
+        - name: Assert boolean slot was rejected
+          ansible.builtin.assert:
+            that:
+              - __invalid_input_slot_bool_failed | default(false)
+            fail_msg: >-
+              assert_role_vars should reject boolean slot values
+
         # --- Test: threshold with invalid range ---
         - name: Assert rejects threshold less than 1
           block:
@@ -281,6 +308,35 @@
                 | default(false)
             fail_msg: >-
               assert_role_vars should reject threshold values less than 1
+
+        # --- Test: threshold as boolean ---
+        - name: Assert rejects boolean threshold
+          block:
+            - name: Run role with boolean threshold
+              ansible.builtin.include_role:
+                name: linux-system-roles.nbde_client
+              vars:
+                nbde_client_bindings:
+                  - device: /dev/sda1
+                    threshold: true
+                    servers:
+                      - http://server1.example.com
+          rescue:
+            - name: Mark boolean threshold rejected
+              ansible.builtin.set_fact:
+                __invalid_input_threshold_bool_failed: true
+              when: >-
+                'must be a positive integer' in
+                (ansible_failed_result | default({}) | to_json)
+
+        - name: Assert boolean threshold was rejected
+          ansible.builtin.assert:
+            that:
+              - >-
+                __invalid_input_threshold_bool_failed
+                | default(false)
+            fail_msg: >-
+              assert_role_vars should reject boolean threshold values
 
         # --- Test: missing servers when state is present ---
         - name: Assert rejects missing servers when state is present
@@ -351,7 +407,9 @@
             __invalid_input_secure_logging_type_failed:
             __invalid_input_extra_dracut_type_failed:
             __invalid_input_slot_range_failed:
+            __invalid_input_slot_bool_failed:
             __invalid_input_threshold_range_failed:
+            __invalid_input_threshold_bool_failed:
             __invalid_input_missing_servers_failed:
             __invalid_input_extra_dracut_early_boot_failed:
           tags: tests::cleanup


### PR DESCRIPTION
Enhancement: Added argument spec and assert role spec validation to the nbde client role. Also wrote tests for it found in tests/tests_invalid_input.

Reason: Because it is a good addition to the linux-system-roles project.

Result: Successfully added it and prepared tests for it. I used AI during this implementation.

Issue Tracker Tickets (Jira or BZ if any): https://github.com/linux-system-roles/postfix/issues/206 https://redhat.atlassian.net/browse/RHELMISC-16008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for role configuration values, including supported providers, required fields, data types, binding slots, thresholds, and server lists.
  * Invalid configurations now fail early with clear, actionable error messages.
* **Documentation**
  * Updated the Role Variables documentation to explain the enforced validation rules.
* **Tests**
  * Added comprehensive coverage for valid defaults and invalid configuration scenarios, including nested binding values and incompatible settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->